### PR TITLE
feat: add privacy-safe runtime diagnostics

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,6 +11,7 @@
 - [x] 实现显式 WASAPI 输出端点枚举、选择、16 kHz PCM 写入、有界队列和真实 padding 排空代码路径。
 - [x] 实现 RC003 选择持久化、意外断连指数退避重连和 Windows 睡眠/恢复通知代码路径；真机恢复仍待验收。
 - [x] 在 Windows 主机编译 Tauri NSIS Preview 安装包；Windows CI 已生成并复验绑定精确来源 Commit、SHA-256 和未签名状态的 artifact，安装、升级、卸载与正式签名仍待完成。
+- [x] 提供去标识化运行诊断摘要和页面内复制入口；自动化已证明不导出设备身份、路径、端点名称或错误原文，Windows WebView 剪贴板仍待运行验收。
 - [ ] 使用真实 RC003 验证 BLE 配对、连接、断开和重连。
 - [ ] 验证 `STREAM_START → AUDIO → STREAM_STOP` 首次会话完整可用。
 - [ ] 在 Windows 真机验证 WASAPI 端点初始化、VB-CABLE 回环、欠载恢复与完整尾音。

--- a/Testing/WindowsRC003Preview.md
+++ b/Testing/WindowsRC003Preview.md
@@ -123,6 +123,18 @@
 
 失败判定：artifact 无法绑定精确 commit、存在多个候选安装器、SHA-256 不一致、CI 包意外带未知签名、安装器要求全局管理员权限、同一版本产生多个安装条目、把未签名 artifact 当作公开发布包。
 
+## 用例十：隐私安全诊断摘要
+
+1. 依次在未连接、连接中、ATVV 就绪、语音流式、排空、断开和失败状态打开“权限”页面。
+2. 点击“生成摘要”，确认页面内 JSON 的阶段、能力、代次和计数与同一时刻的连接、音频、Raw Input 和 SendInput 状态一致。
+3. 搜索摘要，确认不存在真实设备 ID、蓝牙地址、完整 HID 路径、遥控器名称、音频端点 ID/名称、错误原文、窗口标题、语音内容或用户文本。
+4. 点击“复制摘要”，粘贴到本地记事本，确认内容与页面内可见 JSON 逐字一致。
+5. 在 900 × 620 和 1080 × 720 窗口重复生成，确认权限状态、按钮、摘要和滚动均可访问，没有横向裁切。
+
+预期：摘要由当前运行快照即时生成，不读取其他 App 或系统私有数据；敏感字段在 Rust 诊断结构生成阶段即被排除。复制失败必须显示错误，不能显示成功或静默上传。
+
+失败判定：摘要包含任何设备或用户身份、路径、端点名称或错误原文；状态与当前快照不一致；浏览器预览被描述为 Windows 可用；未点击时自动读取或复制；剪贴板写入失败仍提示成功；页面出现横向溢出或中文小于 12pt。
+
 ## 日志收集
 
 日志不得包含语音内容、识别文字、真实蓝牙地址、完整 HID 路径、窗口标题或个人文档路径。报告应包含 Commit、版本、时间段、Windows 版本和失败步骤。
@@ -137,18 +149,20 @@
 
 2026-09-01 在 Apple Silicon Mac 上完成：
 
-- Vue 导航与连接阶段映射测试、类型检查和 Vite 生产构建；
-- 900 × 620 与 1080 × 720 浏览器界面检查，全部五个侧栏入口可打开；
+- Vue 导航、连接阶段映射、诊断格式和权限页复制组件测试、类型检查和 Vite 生产构建；
+- 900 × 620 与 1080 × 720 浏览器界面检查，全部五个侧栏入口可打开；权限页无横向溢出，诊断摘要可在页面内生成和滚动；
 - 浏览器控制台零错误；
-- `sayall-core` 22 项测试；macOS `sayall-windows` 13 项平台边界、退避和 Raw Input 纯逻辑测试；Tauri 设置序列化 2 项测试；Windows CI 额外运行 WASAPI generation、有界队列、持久端点身份、重连调度、电源回调转发、Raw Input 纯逻辑测试和完整 Tauri Host 编译；
+- `sayall-core` 22 项测试；macOS `sayall-windows` 20 项平台边界、退避、Raw Input 和 SendInput 纯逻辑测试；Tauri 设置与诊断 4 项测试；Windows CI 额外运行 WASAPI generation、有界队列、持久端点身份、重连调度、电源回调转发、Raw Input 纯逻辑测试和完整 Tauri Host 编译；
+- 诊断隐私测试使用设备名称、蓝牙地址、端点身份、用户路径、HID 路径和后端错误作为敏感夹具，序列化摘要均未包含这些值；浏览器生成摘要也未出现 `remoteName`、`selectedEndpointId`、`selectedEndpointName` 或 `lastError` 字段；
 - Raw Input 自动化覆盖两种 Windows 设备路径、零/多匹配 fail-closed、6/7/9 字节 HID 报告、RAWHID 批量拆分、重复 key-down、Keyboard/HID 双来源并集、停止释放和语音键隔离；隐藏窗口和真实事件形态仍需 Windows/RC003 验收；
 - 纯 Rust 首次 `CAPS → STREAM_START → AUDIO → STREAM_STOP → DRAIN`、同步帧、8 kHz 拒绝和流外音频测试；
 - macOS 全 workspace `cargo test`、`cargo check` 和格式化检查；
 - `x86_64-pc-windows-msvc` 目标下 WinRT BLE/GATT/ATVV/WASAPI/Raw Input 平台层交叉静态检查。
 - Windows CI Run [`33516627294`](https://github.com/GetSayAll/remote-mic-app-windows/actions/runs/33516627294) 通过；该结果证明 Windows 代码和 Tauri Host 可编译、自动化可运行，不证明隐藏窗口收到真实 RC003 报告。
 - Windows CI Run [`33522534257`](https://github.com/GetSayAll/remote-mic-app-windows/actions/runs/33522534257) 通过并生成 artifact `sayall-windows-unsigned-preview-e11e460f15287468c01225a8ab86b302d59f09d4`；下载后确认只有一个 4,565,134 字节 NSIS 安装器、`SHA256SUMS.txt` 和 `build-metadata.json`，UTF-8 中文文件名可由 macOS `shasum -a 256 -c` 校验，安装器实算 SHA-256 与两份记录一致为 `e1cccf73c8b20487874eadb12eb9823635f52a0d7664c07fe6b8928532d246d6`，metadata 标记 `NotSigned` 和 `unsigned-ci-preview-not-for-public-release`。
+- main Windows CI Run [`33525406955`](https://github.com/GetSayAll/remote-mic-app-windows/actions/runs/33525406955) 从 merge commit `94923dea303a66604b61ca2572fd13d9d48a9d60` 生成同边界 artifact 并通过下载后 SHA-256、metadata、PE/NSIS 文件类型和 UTF-8 校验文件复验。
 
 以上结果只证明 Tauri Windows NSIS 未签名 Preview 可在干净 Windows Runner 生成且产物身份、摘要和来源元数据一致；不能证明安装、升级、卸载、WinRT 运行时、真实 RC003、WASAPI、Raw Input 或 SendInput 已经通过，这些用例仍为 deferred。
 macOS 上对完整 Tauri Host 的 Windows 目标交叉检查需要 `llvm-rc`，本机未提供该 Windows 资源编译器，因此完整 Host 由 `windows-latest` CI 验证。
 
-本次新增动态连接阶段、连接/断开控件、重连/睡眠状态、睡眠恢复通知状态和 WASAPI 端点选择后，应用内浏览器仍没有可用实例，未能重新执行截图、控制台和点击回归；上述 900 × 620、1080 × 720 记录只覆盖此前的静态页面骨架。本次新界面目前仅通过 Vue 类型检查、连接/音频阶段映射测试和 Vite 生产构建。
+诊断复制已通过前端组件测试确认向 Clipboard API 写入完整可见摘要；应用内浏览器的剪贴板回读与页面 Clipboard API 不共享同一自动化通道，因此不能把浏览器提示当作真实 Windows WebView 剪贴板验收。Windows 安装包中的生成、复制和记事本逐字比对仍为 deferred。

--- a/docs/architecture/windows-tauri-roadmap.md
+++ b/docs/architecture/windows-tauri-roadmap.md
@@ -150,6 +150,8 @@ Tauri Host 负责应用生命周期、IPC、托盘和窗口，不直接解析 AT
 
 安装包采用 Tauri NSIS current-user 模式，固定应用 identifier、publisher、开始菜单目录和禁止降级策略。普通 CI 只生成明确标记为 unsigned 的短期 Preview artifact，并同时输出 SHA-256 与 source commit 元数据；该 artifact 只证明可打包，不能替代 Authenticode、SmartScreen、安装升级或真实应用验收。
 
+权限页已接入只读运行诊断摘要：Tauri Host 从现有平台快照提取能力、阶段、代次和计数，并在 Rust 边界直接丢弃设备 ID、蓝牙地址、HID 路径、遥控器名称、音频端点身份、错误原文和用户内容。页面只在用户主动操作后生成并复制可见 JSON；该能力不是持久日志，也不代表任何 Windows 真机路径已通过。
+
 ### 阶段 E：实验性完整 HID
 
 单独研究返回和音量键，不阻塞 Preview。模拟、驱动存在或 HID Tap ready 都不能代替真实按下/释放验收。

--- a/src-tauri/src/diagnostics.rs
+++ b/src-tauri/src/diagnostics.rs
@@ -1,0 +1,206 @@
+use sayall_windows::raw_input::{RawInputPhase, RemoteButton};
+use sayall_windows::send_input::SendInputSnapshot;
+use sayall_windows::{AudioPhase, ConnectionPhase, PlatformSnapshot};
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiagnosticReport {
+    pub schema_version: u32,
+    pub app_version: String,
+    pub platform: String,
+    pub verification_status: String,
+    pub capabilities: DiagnosticCapabilities,
+    pub connection: ConnectionDiagnostic,
+    pub audio: AudioDiagnostic,
+    pub raw_input: RawInputDiagnostic,
+    pub send_input: SendInputDiagnostic,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiagnosticCapabilities {
+    pub windows_api_available: bool,
+    pub ble_scan_available: bool,
+    pub ble_voice_ready: bool,
+    pub wasapi_ready: bool,
+    pub raw_input_ready: bool,
+    pub send_input_ready: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConnectionDiagnostic {
+    pub phase: ConnectionPhase,
+    pub capabilities_confirmed: bool,
+    pub sample_rate: Option<u32>,
+    pub frame_size: Option<usize>,
+    pub decoded_samples: u64,
+    pub generation: u64,
+    pub reconnect_attempt: u32,
+    pub power_notifications_available: bool,
+    pub error_present: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioDiagnostic {
+    pub phase: AudioPhase,
+    pub endpoint_configured: bool,
+    pub queued_samples: u64,
+    pub submitted_samples: u64,
+    pub generation: u64,
+    pub error_present: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RawInputDiagnostic {
+    pub phase: RawInputPhase,
+    pub matched_device_count: u32,
+    pub raw_event_count: u64,
+    pub semantic_edge_count: u64,
+    pub last_button: Option<RemoteButton>,
+    pub last_is_pressed: Option<bool>,
+    pub error_present: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SendInputDiagnostic {
+    pub available: bool,
+    pub submitted_batches: u64,
+    pub submitted_events: u64,
+    pub error_present: bool,
+}
+
+impl DiagnosticReport {
+    pub fn capture(
+        app_version: &str,
+        platform: &PlatformSnapshot,
+        send_input: &SendInputSnapshot,
+    ) -> Self {
+        let atvv = platform.connection.capabilities.as_ref();
+        Self {
+            schema_version: 1,
+            app_version: app_version.to_owned(),
+            platform: platform.platform.clone(),
+            verification_status: platform.verification_status.clone(),
+            capabilities: DiagnosticCapabilities {
+                windows_api_available: platform.windows_api_available,
+                ble_scan_available: platform.ble_scan_available,
+                ble_voice_ready: platform.ble_voice_ready,
+                wasapi_ready: platform.wasapi_ready,
+                raw_input_ready: platform.raw_input_ready,
+                send_input_ready: platform.send_input_ready,
+            },
+            connection: ConnectionDiagnostic {
+                phase: platform.connection.phase,
+                capabilities_confirmed: atvv.is_some(),
+                sample_rate: atvv.map(|capabilities| capabilities.sample_rate),
+                frame_size: atvv.map(|capabilities| capabilities.frame_size),
+                decoded_samples: platform.connection.decoded_samples,
+                generation: platform.connection.generation,
+                reconnect_attempt: platform.connection.reconnect_attempt,
+                power_notifications_available: platform.connection.power_notifications_available,
+                error_present: platform.connection.last_error.is_some(),
+            },
+            audio: AudioDiagnostic {
+                phase: platform.audio.phase,
+                endpoint_configured: platform.audio.selected_endpoint_id.is_some()
+                    && platform.audio.selected_endpoint_name.is_some(),
+                queued_samples: platform.audio.queued_samples,
+                submitted_samples: platform.audio.submitted_samples,
+                generation: platform.audio.generation,
+                error_present: platform.audio.last_error.is_some(),
+            },
+            raw_input: RawInputDiagnostic {
+                phase: platform.raw_input.phase,
+                matched_device_count: platform.raw_input.matched_device_count,
+                raw_event_count: platform.raw_input.raw_event_count,
+                semantic_edge_count: platform.raw_input.semantic_edge_count,
+                last_button: platform.raw_input.last_button,
+                last_is_pressed: platform.raw_input.last_is_pressed,
+                error_present: platform.raw_input.last_error.is_some(),
+            },
+            send_input: SendInputDiagnostic {
+                available: send_input.available,
+                submitted_batches: send_input.submitted_batches,
+                submitted_events: send_input.submitted_events,
+                error_present: send_input.last_error.is_some(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sayall_windows::raw_input::{RawInputSnapshot, RemoteButton};
+    use sayall_windows::{AudioSnapshot, ConnectionSnapshot};
+
+    #[test]
+    fn diagnostic_report_excludes_device_identity_paths_and_error_text() {
+        let platform = PlatformSnapshot {
+            platform: "windows".to_owned(),
+            windows_api_available: true,
+            ble_scan_available: true,
+            ble_voice_ready: false,
+            wasapi_ready: false,
+            raw_input_ready: true,
+            send_input_ready: true,
+            verification_status: "真机验证中".to_owned(),
+            connection: ConnectionSnapshot {
+                remote_name: Some("私人遥控器名称".to_owned()),
+                last_error: Some("蓝牙地址 AA:BB:CC:DD:EE:FF".to_owned()),
+                generation: 7,
+                reconnect_attempt: 2,
+                ..ConnectionSnapshot::default()
+            },
+            audio: AudioSnapshot {
+                selected_endpoint_id: Some("private-endpoint-id".to_owned()),
+                selected_endpoint_name: Some("私人音频端点".to_owned()),
+                last_error: Some("C:\\Users\\person\\private-path".to_owned()),
+                submitted_samples: 320,
+                ..AudioSnapshot::default()
+            },
+            raw_input: RawInputSnapshot {
+                phase: RawInputPhase::Ready,
+                matched_device_count: 1,
+                raw_event_count: 4,
+                semantic_edge_count: 2,
+                last_button: Some(RemoteButton::Ok),
+                last_is_pressed: Some(false),
+                last_error: Some("\\\\?\\HID#private-device-path".to_owned()),
+            },
+        };
+        let send_input = SendInputSnapshot {
+            available: true,
+            submitted_batches: 1,
+            submitted_events: 4,
+            last_error: Some("private SendInput backend details".to_owned()),
+        };
+
+        let report = DiagnosticReport::capture("0.1.0", &platform, &send_input);
+        let json = serde_json::to_string(&report).unwrap();
+
+        assert_eq!(report.connection.generation, 7);
+        assert!(report.audio.endpoint_configured);
+        assert_eq!(report.raw_input.last_button, Some(RemoteButton::Ok));
+        assert!(report.connection.error_present);
+        assert!(report.audio.error_present);
+        assert!(report.raw_input.error_present);
+        assert!(report.send_input.error_present);
+        for secret in [
+            "私人遥控器名称",
+            "AA:BB:CC:DD:EE:FF",
+            "private-endpoint-id",
+            "私人音频端点",
+            "private-path",
+            "private-device-path",
+            "private SendInput backend details",
+        ] {
+            assert!(!json.contains(secret), "diagnostic leaked {secret}");
+        }
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,7 +9,10 @@ use settings::SettingsStore;
 use std::sync::RwLock;
 use tauri::Manager;
 
+mod diagnostics;
 mod settings;
+
+use diagnostics::DiagnosticReport;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -31,6 +34,13 @@ fn get_runtime_snapshot(state: tauri::State<'_, AppState>) -> RuntimeSnapshot {
         app_version: env!("CARGO_PKG_VERSION"),
         platform: state.platform.snapshot(),
     }
+}
+
+#[tauri::command]
+fn get_diagnostic_report(state: tauri::State<'_, AppState>) -> DiagnosticReport {
+    let platform = state.platform.snapshot();
+    let send_input = state.platform.send_input_snapshot();
+    DiagnosticReport::capture(env!("CARGO_PKG_VERSION"), &platform, &send_input)
 }
 
 #[tauri::command]
@@ -255,6 +265,7 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             get_runtime_snapshot,
+            get_diagnostic_report,
             scan_paired_remotes,
             get_connection_snapshot,
             connect_remote,

--- a/src/lib/bridge.test.ts
+++ b/src/lib/bridge.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   audioPhaseLabel,
   connectionPhaseLabel,
+  formatDiagnosticReport,
   type AudioPhase,
   type ConnectionPhase,
+  type DiagnosticReport,
 } from "./bridge";
 
 describe("connection phase presentation", () => {
@@ -55,5 +57,64 @@ describe("connection phase presentation", () => {
       "WASAPI 输出失败",
       "当前环境不支持 WASAPI",
     ]);
+  });
+});
+
+describe("diagnostic report presentation", () => {
+  it("adds an explicit generation time without changing the captured report", () => {
+    const report: DiagnosticReport = {
+      schemaVersion: 1,
+      appVersion: "0.1.0",
+      platform: "windows",
+      verificationStatus: "待真机验证",
+      capabilities: {
+        windowsApiAvailable: true,
+        bleScanAvailable: true,
+        bleVoiceReady: false,
+        wasapiReady: false,
+        rawInputReady: false,
+        sendInputReady: true,
+      },
+      connection: {
+        phase: "disconnected",
+        capabilitiesConfirmed: false,
+        sampleRate: null,
+        frameSize: null,
+        decodedSamples: 0,
+        generation: 2,
+        reconnectAttempt: 1,
+        powerNotificationsAvailable: true,
+        errorPresent: false,
+      },
+      audio: {
+        phase: "unconfigured",
+        endpointConfigured: false,
+        queuedSamples: 0,
+        submittedSamples: 0,
+        generation: 0,
+        errorPresent: false,
+      },
+      rawInput: {
+        phase: "stopped",
+        matchedDeviceCount: 0,
+        rawEventCount: 0,
+        semanticEdgeCount: 0,
+        lastButton: null,
+        lastIsPressed: null,
+        errorPresent: false,
+      },
+      sendInput: {
+        available: true,
+        submittedBatches: 0,
+        submittedEvents: 0,
+        errorPresent: false,
+      },
+    };
+
+    const formatted = JSON.parse(formatDiagnosticReport(report, "2026-09-01T00:00:00.000Z"));
+    expect(formatted.generatedAt).toBe("2026-09-01T00:00:00.000Z");
+    expect(formatted.connection.generation).toBe(2);
+    expect(formatted).not.toHaveProperty("remoteName");
+    expect(formatted.audio).not.toHaveProperty("selectedEndpointName");
   });
 });

--- a/src/lib/bridge.ts
+++ b/src/lib/bridge.ts
@@ -127,6 +127,55 @@ export interface RuntimeSnapshot {
   platform: PlatformSnapshot;
 }
 
+export interface DiagnosticReport {
+  schemaVersion: number;
+  appVersion: string;
+  platform: string;
+  verificationStatus: string;
+  capabilities: {
+    windowsApiAvailable: boolean;
+    bleScanAvailable: boolean;
+    bleVoiceReady: boolean;
+    wasapiReady: boolean;
+    rawInputReady: boolean;
+    sendInputReady: boolean;
+  };
+  connection: {
+    phase: ConnectionPhase;
+    capabilitiesConfirmed: boolean;
+    sampleRate: number | null;
+    frameSize: number | null;
+    decodedSamples: number;
+    generation: number;
+    reconnectAttempt: number;
+    powerNotificationsAvailable: boolean;
+    errorPresent: boolean;
+  };
+  audio: {
+    phase: AudioPhase;
+    endpointConfigured: boolean;
+    queuedSamples: number;
+    submittedSamples: number;
+    generation: number;
+    errorPresent: boolean;
+  };
+  rawInput: {
+    phase: RawInputPhase;
+    matchedDeviceCount: number;
+    rawEventCount: number;
+    semanticEdgeCount: number;
+    lastButton: RemoteButton | null;
+    lastIsPressed: boolean | null;
+    errorPresent: boolean;
+  };
+  sendInput: {
+    available: boolean;
+    submittedBatches: number;
+    submittedEvents: number;
+    errorPresent: boolean;
+  };
+}
+
 export interface PairedRemote {
   id: string;
   name: string;
@@ -185,6 +234,67 @@ export async function getRuntimeSnapshot(): Promise<RuntimeSnapshot> {
     return browserSnapshot;
   }
   return invoke<RuntimeSnapshot>("get_runtime_snapshot");
+}
+
+export async function getDiagnosticReport(): Promise<DiagnosticReport> {
+  if (!isTauriRuntime()) {
+    return {
+      schemaVersion: 1,
+      appVersion: browserSnapshot.appVersion,
+      platform: browserSnapshot.platform.platform,
+      verificationStatus: browserSnapshot.platform.verificationStatus,
+      capabilities: {
+        windowsApiAvailable: false,
+        bleScanAvailable: false,
+        bleVoiceReady: false,
+        wasapiReady: false,
+        rawInputReady: false,
+        sendInputReady: false,
+      },
+      connection: {
+        phase: browserSnapshot.platform.connection.phase,
+        capabilitiesConfirmed: false,
+        sampleRate: null,
+        frameSize: null,
+        decodedSamples: 0,
+        generation: 0,
+        reconnectAttempt: 0,
+        powerNotificationsAvailable: false,
+        errorPresent: false,
+      },
+      audio: {
+        phase: browserSnapshot.platform.audio.phase,
+        endpointConfigured: false,
+        queuedSamples: 0,
+        submittedSamples: 0,
+        generation: 0,
+        errorPresent: false,
+      },
+      rawInput: {
+        phase: browserSnapshot.platform.rawInput.phase,
+        matchedDeviceCount: 0,
+        rawEventCount: 0,
+        semanticEdgeCount: 0,
+        lastButton: null,
+        lastIsPressed: null,
+        errorPresent: false,
+      },
+      sendInput: {
+        available: false,
+        submittedBatches: 0,
+        submittedEvents: 0,
+        errorPresent: false,
+      },
+    };
+  }
+  return invoke<DiagnosticReport>("get_diagnostic_report");
+}
+
+export function formatDiagnosticReport(
+  report: DiagnosticReport,
+  generatedAt = new Date().toISOString(),
+): string {
+  return JSON.stringify({ generatedAt, ...report }, null, 2);
 }
 
 export async function scanPairedRemotes(): Promise<PairedRemote[]> {

--- a/src/pages/PermissionsPage.test.ts
+++ b/src/pages/PermissionsPage.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+
+import { flushPromises, mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeSnapshot } from "../lib/bridge";
+import PermissionsPage from "./PermissionsPage.vue";
+
+const runtime: RuntimeSnapshot = {
+  appVersion: "0.1.0",
+  platform: {
+    platform: "browser-preview",
+    windowsApiAvailable: false,
+    bleScanAvailable: false,
+    bleVoiceReady: false,
+    wasapiReady: false,
+    rawInputReady: false,
+    sendInputReady: false,
+    verificationStatus: "浏览器预览不代表 Windows 真机通过",
+    connection: {
+      phase: "idle",
+      remoteName: null,
+      capabilities: null,
+      voiceState: "idle",
+      decodedSamples: 0,
+      generation: 0,
+      reconnectAttempt: 0,
+      powerNotificationsAvailable: false,
+      lastError: null,
+    },
+    audio: {
+      phase: "unsupported",
+      selectedEndpointId: null,
+      selectedEndpointName: null,
+      queuedSamples: 0,
+      submittedSamples: 0,
+      generation: 0,
+      lastError: null,
+    },
+    rawInput: {
+      phase: "unsupported",
+      matchedDeviceCount: 0,
+      rawEventCount: 0,
+      semanticEdgeCount: 0,
+      lastButton: null,
+      lastIsPressed: null,
+      lastError: null,
+    },
+  },
+};
+
+describe("permissions diagnostics", () => {
+  const writeText = vi.fn<(text: string) => Promise<void>>();
+
+  beforeEach(() => {
+    writeText.mockReset();
+    writeText.mockResolvedValue();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+  });
+
+  it("shows truthful unsupported states and copies the generated privacy-safe report", async () => {
+    const wrapper = mount(PermissionsPage, { props: { runtime } });
+    expect(wrapper.text()).not.toContain("尚未实现");
+    expect(wrapper.text()).toContain("当前主机不可用");
+
+    const buttons = wrapper.findAll(".diagnostics-card button");
+    await buttons[0].trigger("click");
+    await flushPromises();
+
+    const report = wrapper.get(".diagnostic-output").text();
+    expect(report).toContain('"schemaVersion": 1');
+    expect(report).not.toContain("remoteName");
+    expect(report).not.toContain("selectedEndpointName");
+    expect(report).not.toContain("lastError");
+
+    await buttons[1].trigger("click");
+    await flushPromises();
+
+    expect(writeText).toHaveBeenCalledOnce();
+    expect(writeText).toHaveBeenCalledWith(report);
+    expect(wrapper.text()).toContain("诊断摘要已复制到剪贴板");
+  });
+});

--- a/src/pages/PermissionsPage.vue
+++ b/src/pages/PermissionsPage.vue
@@ -1,6 +1,60 @@
 <script setup lang="ts">
-import type { RuntimeSnapshot } from "../lib/bridge";
-defineProps<{ runtime: RuntimeSnapshot | null }>();
+import { computed, ref } from "vue";
+import {
+  formatDiagnosticReport,
+  getDiagnosticReport,
+  type RuntimeSnapshot,
+} from "../lib/bridge";
+
+const props = defineProps<{ runtime: RuntimeSnapshot | null }>();
+
+const diagnosticText = ref("");
+const diagnosticMessage = ref("尚未生成诊断摘要");
+const generatingDiagnostic = ref(false);
+
+const bluetoothStatus = computed(() => {
+  if (props.runtime?.platform.bleVoiceReady) return { tone: "success", label: "语音链路已就绪" };
+  if (props.runtime?.platform.bleScanAvailable) return { tone: "warning", label: "API 可用，待真机验证" };
+  return { tone: "pending", label: "当前主机不可用" };
+});
+
+const inputStatus = computed(() => {
+  if (props.runtime?.platform.rawInputReady) return { tone: "success", label: "Raw Input 已运行" };
+  if (props.runtime?.platform.windowsApiAvailable) return { tone: "warning", label: "可启动，待真机验证" };
+  return { tone: "pending", label: "当前主机不可用" };
+});
+
+const audioStatus = computed(() => {
+  if (props.runtime?.platform.wasapiReady) return { tone: "success", label: "WASAPI 已就绪" };
+  if (props.runtime?.platform.windowsApiAvailable) return { tone: "warning", label: "待选择输出端点" };
+  return { tone: "pending", label: "当前主机不可用" };
+});
+
+async function generateDiagnostic() {
+  generatingDiagnostic.value = true;
+  diagnosticMessage.value = "正在读取当前运行状态…";
+  try {
+    diagnosticText.value = formatDiagnosticReport(await getDiagnosticReport());
+    diagnosticMessage.value = "诊断摘要已生成；复制前可在页面内检查全部内容";
+  } catch (error) {
+    diagnosticText.value = "";
+    diagnosticMessage.value = error instanceof Error ? error.message : String(error);
+  } finally {
+    generatingDiagnostic.value = false;
+  }
+}
+
+async function copyDiagnostic() {
+  if (!diagnosticText.value) await generateDiagnostic();
+  if (!diagnosticText.value) return;
+  try {
+    if (!navigator.clipboard?.writeText) throw new Error("当前环境不支持剪贴板写入");
+    await navigator.clipboard.writeText(diagnosticText.value);
+    diagnosticMessage.value = "诊断摘要已复制到剪贴板";
+  } catch (error) {
+    diagnosticMessage.value = error instanceof Error ? error.message : String(error);
+  }
+}
 </script>
 
 <template>
@@ -8,7 +62,7 @@ defineProps<{ runtime: RuntimeSnapshot | null }>();
     <header class="page-header">
       <div>
         <h1>权限</h1>
-        <p>主程序保持普通用户权限，只使用 Windows 公共 API。</p>
+        <p>主程序保持普通用户权限，只使用 Windows 公共 API；状态只代表当前运行时，不替代真机验收。</p>
       </div>
     </header>
 
@@ -16,24 +70,43 @@ defineProps<{ runtime: RuntimeSnapshot | null }>();
       <div class="permission-row">
         <div class="permission-icon">BT</div>
         <div><strong>Bluetooth LE</strong><p>读取已配对设备，并在后续阶段连接 RC003 GATT 服务。</p></div>
-        <span class="badge" :class="runtime?.platform.bleScanAvailable ? 'warning' : 'pending'">
-          {{ runtime?.platform.bleScanAvailable ? "API 可调用，待验证" : "当前主机不可用" }}
+        <span class="badge" :class="bluetoothStatus.tone">
+          {{ bluetoothStatus.label }}
         </span>
       </div>
       <div class="permission-row">
         <div class="permission-icon">IN</div>
-        <div><strong>Raw Input 与 SendInput</strong><p>仅处理明确识别的遥控器，不拦截普通键盘。</p></div>
-        <span class="badge pending">尚未实现</span>
+        <div><strong>Raw Input 与 SendInput</strong><p>只匹配 RC003 设备路径；自动映射仍等待真机事件形态确认。</p></div>
+        <span class="badge" :class="inputStatus.tone">{{ inputStatus.label }}</span>
       </div>
       <div class="permission-row">
         <div class="permission-icon">AU</div>
         <div><strong>音频端点</strong><p>用户明确选择 WASAPI 输出端点，不更改系统默认设备。</p></div>
-        <span class="badge pending">尚未实现</span>
+        <span class="badge" :class="audioStatus.tone">{{ audioStatus.label }}</span>
       </div>
     </article>
 
     <div class="info-callout">
       基础语音路径不依赖 Frida、管理员权限、第三方 App 私有配置或虚拟 HID 驱动。
     </div>
+
+    <article class="card diagnostics-card">
+      <div class="card-title-row">
+        <div>
+          <h2>诊断摘要</h2>
+          <p class="muted">只包含阶段、能力、代次和计数；不包含设备 ID、蓝牙地址、HID 路径、音频端点名称、错误原文、窗口标题、语音或用户文本。</p>
+        </div>
+        <div class="button-row">
+          <button class="secondary-button" type="button" :disabled="generatingDiagnostic" @click="generateDiagnostic">
+            {{ generatingDiagnostic ? "生成中…" : "生成摘要" }}
+          </button>
+          <button class="primary-button" type="button" :disabled="generatingDiagnostic" @click="copyDiagnostic">
+            复制摘要
+          </button>
+        </div>
+      </div>
+      <p class="operation-message" aria-live="polite">{{ diagnosticMessage }}</p>
+      <pre v-if="diagnosticText" class="diagnostic-output">{{ diagnosticText }}</pre>
+    </article>
   </section>
 </template>

--- a/src/styles.css
+++ b/src/styles.css
@@ -151,6 +151,23 @@ button:disabled { cursor: not-allowed; opacity: 0.55; }
 .permission-row strong { font-size: 16px; }
 .permission-row p { margin: 4px 0 0; color: var(--muted); font-size: 16px; }
 .permission-icon { width: 38px; height: 38px; display: grid; place-items: center; border-radius: 10px; color: #575bc6; background: #eeeeff; font-size: 12px; font-weight: 700; }
+.diagnostics-card { margin-top: 18px; }
+.diagnostics-card .muted { max-width: 700px; margin-bottom: 0; }
+.diagnostic-output {
+  max-height: 360px;
+  margin: 16px 0 0;
+  padding: 16px;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  color: #303542;
+  background: #f6f7fa;
+  font-family: "Cascadia Mono", "Consolas", monospace;
+  font-size: 16px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
 .about-card { display: flex; align-items: center; gap: 18px; margin-bottom: 18px; }
 .app-icon { width: 64px; height: 64px; flex: 0 0 auto; border-radius: 16px; font-size: 28px; font-weight: 700; }
 .about-card p { margin: 4px 0 0; }


### PR DESCRIPTION
## 变更

- 新增只读 Tauri 诊断命令，导出能力、阶段、代次和计数
- 在 Rust 边界排除设备 ID、蓝牙地址、HID 路径、遥控器名称、端点身份、错误原文和用户内容
- 权限页改为展示真实 BLE、Raw Input、SendInput 和 WASAPI 运行状态
- 提供页面内生成、检查和复制诊断 JSON
- 补充隐私夹具测试、权限页组件测试、真机测试手册、TODO 和架构说明

## 已验证

- cargo test --workspace
- cargo check --workspace
- cargo fmt --all -- --check
- pnpm test
- pnpm build
- pnpm tauri build --no-bundle
- git diff --check
- 900 × 620、1080 × 720 页面交互与无横向溢出检查
- 浏览器控制台零错误

## 验证边界

Mac 和浏览器自动化证明诊断结构不会序列化敏感夹具，并证明页面把完整可见摘要交给 Clipboard API。Windows WebView 剪贴板、真实 RC003/WASAPI/Raw Input 状态和记事本逐字比对仍为 deferred；本 PR 不接通 Raw Input 到 SendInput 的自动执行。