### PR TITLE
feat: enforce Windows 10 1809 minimum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2582,6 +2582,7 @@ dependencies = [
  "thiserror 2.0.20",
  "wasapi",
  "windows 0.62.2",
+ "windows-version",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - 可区分连接、特征发现、能力确认、就绪、流式接收、排空、断开和失败的真实状态界面；
 - 设备路径限定的 Raw Input、批量 SendInput、映射持久化与显式快捷键测试；
 - 仅保存在本机的每日按键、完整语音会话和语音时长统计，以及今日、本周、全部和最近 7 天展示；
+- Windows 10 1809（build 17763）安装与启动双层版本门禁；
 - Windows CI 可生成带 SHA-256 和来源元数据的未签名 NSIS Preview artifact；
 - Windows CI、来源归属和真机测试手册。
 
@@ -40,7 +41,7 @@ sayall-windows    WinRT BLE、Raw Input、SendInput、WASAPI
 - Visual Studio Build Tools，包含“使用 C++ 的桌面开发”；
 - WebView2 Runtime。
 
-Mac 可以运行前端构建和纯 Rust 测试，但不能证明 WinRT BLE、Raw Input、WASAPI、安装器或 RC003 真机行为。
+Mac 可以运行前端构建和纯 Rust 测试，但不能证明 WinRT BLE、Raw Input、WASAPI、安装器版本提示或 RC003 真机行为。
 当前平台层已通过 `x86_64-pc-windows-msvc` 交叉静态检查；这只能证明 WinRT、WASAPI API 符号和类型可编译，Windows 运行时、VB-CABLE 回环与 RC003 真机结果仍以 Windows CI 和测试手册为准。
 
 ## 本地检查

--- a/TODO.md
+++ b/TODO.md
@@ -13,12 +13,13 @@
 - [x] 在 Windows 主机编译 Tauri NSIS Preview 安装包；Windows CI 已生成并复验绑定精确来源 Commit、SHA-256 和未签名状态的 artifact，安装、升级、卸载与正式签名仍待完成。
 - [x] 提供去标识化运行诊断摘要和页面内复制入口；自动化已证明不导出设备身份、路径、端点名称或错误原文，Windows WebView 剪贴板仍待运行验收。
 - [x] 持久化并展示仅保存在本机的每日按键次数、完整语音会话次数和语音采样时长；Windows/RC003 真实事件计数与升级保留仍待真机验收。
+- [x] 对低于 Windows 10 1809（build 17763）的系统增加 NSIS 安装与应用启动双层拒绝门禁；Windows 10 1809 / Windows 11 提示和安装行为仍待真机验收。
 - [ ] 使用真实 RC003 验证 BLE 配对、连接、断开和重连。
 - [ ] 验证 `STREAM_START → AUDIO → STREAM_STOP` 首次会话完整可用。
 - [ ] 在 Windows 真机验证 WASAPI 端点初始化、VB-CABLE 回环、欠载恢复与完整尾音。
 - [x] 持久化用户选择的输出端点，并在端点消失或更名时失败关闭；Windows 运行时恢复仍待真机验收。
 - [x] 实现设备路径 fail-closed、隐藏消息窗口、Keyboard/HID 双来源合并和停止释放的 Raw Input 代码路径；Windows 与 RC003 真机按键验收仍待完成。
 - [ ] 实现按键映射保存、热加载和 SendInput：独立映射文件、显式热加载、批量 SendInput、部分提交回滚和界面测试已完成；真实 Raw Input 边沿自动执行须等待 Windows/RC003 确认 Keyboard/HID 事件形态，避免重复输入。
-- [ ] 完成 Windows 10/11 安装、升级和卸载验证。
+- [ ] 完成 Windows 10 1809 / Windows 11 安装、升级和卸载验证。
 - [ ] 建立自签 Authenticode、证书指纹和 SHA-256 发布流程。
 - [ ] 单独评估返回键、音量键等完整 HID 实验能力。

--- a/Testing/WindowsRC003Preview.md
+++ b/Testing/WindowsRC003Preview.md
@@ -5,7 +5,7 @@
 - 仓库：`GetSayAll/remote-mic-app-windows`
 - 平台：Windows 10 1809+ / Windows 11 x64
 - 硬件：小米蓝牙语音遥控器 2 Pro / RC003
-- 当前状态：WinRT BLE / ATVV / PCM / WASAPI、端点持久化、退避重连、睡眠恢复、Raw Input 和本机使用统计代码路径已实现；Windows、RC003、VB-CABLE 真机验收 deferred
+- 当前状态：WinRT BLE / ATVV / PCM / WASAPI、端点持久化、退避重连、睡眠恢复、Raw Input、本机使用统计和 Windows 10 1809 双层版本门禁代码路径已实现；Windows、RC003、VB-CABLE 真机验收 deferred
 
 ## 测试前准备
 
@@ -15,6 +15,17 @@
 4. 若测试虚拟麦克风，单独安装 VB-CABLE，并重启 Windows。
 5. 准备记事本和至少一个真实语音输入应用。
 6. 保存测试开始前的应用日志。
+
+## 用例零：Windows 版本门禁
+
+1. 在低于 Windows 10 1809（build 17763）的隔离虚拟机运行 NSIS 安装器。
+2. 确认安装器显示最低版本提示并退出，应用文件、快捷方式和卸载条目均未创建；WebView2 bootstrapper 是否已发生动作需单独记录。
+3. 将已解压的应用 exe 直接复制到同一虚拟机并运行。
+4. 在 Windows 10 1809 x64 和当前 Windows 11 x64 分别安装并启动同一候选。
+
+预期：低于 build 17763 时，安装器在复制应用文件前以退出码 1633 失败关闭；直接运行 exe 时在创建 WebView、BLE、WASAPI 或 Raw Input 资源前显示原生中英文提示并退出。Windows 10 1809 和更高版本不触发版本拒绝，继续进入正常安装与启动流程。
+
+失败判定：只在文档声明最低版本；低版本仍复制应用文件或启动后台平台线程；直接运行 exe 崩溃、静默退出或进入主界面；Windows 10 1809 被误拒绝；把 CI 编译或纯逻辑测试表述为已完成上述虚拟机/真机验收。
 
 ## 用例一：首次连接
 
@@ -185,6 +196,13 @@
 - Vue 组件覆盖今日、本周、全部切换、时长格式、最近 7 天数据和零数据空状态；900 × 620 与 1080 × 720 浏览器检查无横向溢出，新增统计界面最终字号不小于 16px，控制台零 warning/error；
 - `x86_64-pc-windows-msvc` 目标下 `sayall-windows` 平台层静态检查通过；完整 Tauri Host 交叉检查在 Mac 上仍受缺少 `llvm-rc` 限制，交由 `windows-latest` CI 验证；
 - Windows/RC003 真实按键计数、真实语音计数、跨自然日、退出落盘和升级保留均为 deferred，必须执行用例十一后才能称为真机通过。
+
+2026-09-02 在 Apple Silicon Mac 上完成 Windows 10 1809 版本门禁实现级验证：
+
+- 纯 Rust 版本比较覆盖 Windows 10 build 17762 拒绝、17763 边界接受、更新 Windows 10 build 和未来主版本接受；
+- `sayall-windows` 的 `x86_64-pc-windows-msvc` 静态检查通过，确认 `RtlGetVersion` 封装与原生 `MessageBoxW` 代码可编译；
+- Tauri 配置解析、macOS workspace 测试/检查、前端 8 项测试、生产构建和 `tauri build --no-bundle` 通过；
+- NSIS hook 的实际编译交由 Windows CI；低版本安装提示、退出码 1633、直接运行 exe、Windows 10 1809 接受和 Windows 11 接受仍为 deferred，必须执行用例零后才能称为运行验收通过。
 
 以上结果只证明 Tauri Windows NSIS 未签名 Preview 可在干净 Windows Runner 生成且产物身份、摘要和来源元数据一致；不能证明安装、升级、卸载、WinRT 运行时、真实 RC003、WASAPI、Raw Input 或 SendInput 已经通过，这些用例仍为 deferred。
 macOS 上对完整 Tauri Host 的 Windows 目标交叉检查需要 `llvm-rc`，本机未提供该 Windows 资源编译器，因此完整 Host 由 `windows-latest` CI 验证。

--- a/crates/sayall-windows/Cargo.toml
+++ b/crates/sayall-windows/Cargo.toml
@@ -13,6 +13,7 @@ thiserror.workspace = true
 [target.'cfg(windows)'.dependencies]
 futures = "0.3"
 wasapi = "0.24"
+windows-version = "0.1.7"
 windows = { version = "0.62", features = [
     "Devices_Bluetooth",
     "Devices_Bluetooth_GenericAttributeProfile",

--- a/crates/sayall-windows/src/compatibility.rs
+++ b/crates/sayall-windows/src/compatibility.rs
@@ -1,0 +1,120 @@
+use std::fmt;
+
+pub const MINIMUM_WINDOWS_VERSION: WindowsVersion = WindowsVersion::new(10, 0, 17_763);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WindowsVersion {
+    pub major: u32,
+    pub minor: u32,
+    pub build: u32,
+}
+
+impl WindowsVersion {
+    pub const fn new(major: u32, minor: u32, build: u32) -> Self {
+        Self {
+            major,
+            minor,
+            build,
+        }
+    }
+
+    const fn is_at_least(self, minimum: Self) -> bool {
+        self.major > minimum.major
+            || (self.major == minimum.major
+                && (self.minor > minimum.minor
+                    || (self.minor == minimum.minor && self.build >= minimum.build)))
+    }
+}
+
+impl fmt::Display for WindowsVersion {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}.{}.{}", self.major, self.minor, self.build)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnsupportedWindowsVersion {
+    pub current: WindowsVersion,
+    pub minimum: WindowsVersion,
+}
+
+impl fmt::Display for UnsupportedWindowsVersion {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "当前 Windows 版本 {} 不受支持；无线麦 SayAll 需要 Windows 10 1809（{}）或更高版本",
+            self.current, self.minimum
+        )
+    }
+}
+
+impl std::error::Error for UnsupportedWindowsVersion {}
+
+pub fn check_supported_windows(current: WindowsVersion) -> Result<(), UnsupportedWindowsVersion> {
+    if current.is_at_least(MINIMUM_WINDOWS_VERSION) {
+        Ok(())
+    } else {
+        Err(UnsupportedWindowsVersion {
+            current,
+            minimum: MINIMUM_WINDOWS_VERSION,
+        })
+    }
+}
+
+#[cfg(windows)]
+pub fn check_current_windows() -> Result<(), UnsupportedWindowsVersion> {
+    let current = windows_version::OsVersion::current();
+    check_supported_windows(WindowsVersion::new(
+        current.major,
+        current.minor,
+        current.build,
+    ))
+}
+
+#[cfg(windows)]
+pub fn show_unsupported_windows_message(error: UnsupportedWindowsVersion) {
+    use windows::core::{w, PCWSTR};
+    use windows::Win32::UI::WindowsAndMessaging::{MessageBoxW, MB_ICONERROR, MB_OK};
+
+    let message = format!("{error}\r\n\r\nSayAll requires Windows 10 1809 (build 17763) or later.");
+    let message: Vec<u16> = message.encode_utf16().chain(std::iter::once(0)).collect();
+    unsafe {
+        let _ = MessageBoxW(
+            None,
+            PCWSTR(message.as_ptr()),
+            w!("无线麦 SayAll"),
+            MB_OK | MB_ICONERROR,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_windows_10_1809_and_later() {
+        assert_eq!(
+            check_supported_windows(WindowsVersion::new(10, 0, 17_763)),
+            Ok(())
+        );
+        assert_eq!(
+            check_supported_windows(WindowsVersion::new(10, 0, 22_000)),
+            Ok(())
+        );
+        assert_eq!(
+            check_supported_windows(WindowsVersion::new(11, 0, 1)),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn rejects_older_windows_versions() {
+        let error = check_supported_windows(WindowsVersion::new(10, 0, 17_762))
+            .expect_err("Windows 10 1803 must be rejected");
+        assert_eq!(error.current, WindowsVersion::new(10, 0, 17_762));
+        assert_eq!(error.minimum, MINIMUM_WINDOWS_VERSION);
+
+        assert!(check_supported_windows(WindowsVersion::new(6, 3, 9_600)).is_err());
+    }
+}

--- a/crates/sayall-windows/src/lib.rs
+++ b/crates/sayall-windows/src/lib.rs
@@ -9,6 +9,7 @@ use thiserror::Error;
 mod audio;
 #[cfg(windows)]
 mod ble;
+pub mod compatibility;
 #[cfg(windows)]
 mod power;
 pub mod raw_input;

--- a/docs/architecture/windows-tauri-roadmap.md
+++ b/docs/architecture/windows-tauri-roadmap.md
@@ -148,7 +148,7 @@ Tauri Host 负责应用生命周期、IPC、托盘和窗口，不直接解析 AT
 - 安装、升级、卸载和更新；
 - 自签 Authenticode、证书指纹和 SHA-256。
 
-安装包采用 Tauri NSIS current-user 模式，固定应用 identifier、publisher、开始菜单目录和禁止降级策略。普通 CI 只生成明确标记为 unsigned 的短期 Preview artifact，并同时输出 SHA-256 与 source commit 元数据；该 artifact 只证明可打包，不能替代 Authenticode、SmartScreen、安装升级或真实应用验收。
+安装包采用 Tauri NSIS current-user 模式，固定应用 identifier、publisher、开始菜单目录和禁止降级策略。最低系统版本统一定义为 Windows 10 1809（build 17763）：NSIS 在复制应用文件前通过官方 installer hook 拒绝更低 build，Tauri Host 在创建 WebView、BLE、WASAPI 和 Raw Input 资源前再次读取真实系统版本并失败关闭，覆盖绕过安装器直接运行 exe 的情况。普通 CI 校验 hook 路径与门槛值，并只生成明确标记为 unsigned 的短期 Preview artifact；该 artifact 只证明代码和打包结构可构建，不能替代 Windows 10 1809 / Windows 11 上的提示、安装升级、Authenticode 或 SmartScreen 真机验收。
 
 权限页已接入只读运行诊断摘要：Tauri Host 从现有平台快照提取能力、阶段、代次和计数，并在 Rust 边界直接丢弃设备 ID、蓝牙地址、HID 路径、遥控器名称、音频端点身份、错误原文和用户内容。页面只在用户主动操作后生成并复制可见 JSON；该能力不是持久日志，也不代表任何 Windows 真机路径已通过。
 
@@ -174,6 +174,7 @@ Mac 开发机不能证明：
 - WASAPI 和 VB-CABLE；
 - SendInput 对真实目标应用有效；
 - Windows 安装、升级、签名和 SmartScreen；
+- Windows 10 1809 / Windows 11 的安装与启动版本门禁提示；
 - 真实语音首次会话完整可用。
 
 这些项目必须在 Windows 主机按 `Testing/WindowsRC003Preview.md` 完成。

--- a/scripts/verify-windows-bundle.ps1
+++ b/scripts/verify-windows-bundle.ps1
@@ -31,7 +31,7 @@ if (-not (Test-Path -LiteralPath $installerHooksPath -PathType Leaf)) {
     throw "NSIS installer hooks file is missing: $installerHooksPath"
 }
 $installerHooks = Get-Content -Raw -Encoding UTF8 $installerHooksPath
-if ($installerHooks -notmatch '(?m)^!define SAYALL_MINIMUM_WINDOWS_BUILD 17763$') {
+if ($installerHooks -notmatch '(?m)^!define SAYALL_MINIMUM_WINDOWS_BUILD 17763\r?$') {
     throw "NSIS installer minimum Windows build must remain 17763"
 }
 if (

--- a/scripts/verify-windows-bundle.ps1
+++ b/scripts/verify-windows-bundle.ps1
@@ -2,6 +2,7 @@ $ErrorActionPreference = "Stop"
 
 $repositoryRoot = Split-Path -Parent $PSScriptRoot
 $configPath = Join-Path $repositoryRoot "src-tauri/tauri.conf.json"
+$compatibilitySourcePath = Join-Path $repositoryRoot "crates/sayall-windows/src/compatibility.rs"
 $bundleDirectory = Join-Path $repositoryRoot "target/release/bundle/nsis"
 $artifactDirectory = Join-Path $repositoryRoot "artifacts/windows-preview"
 
@@ -20,6 +21,30 @@ if ($config.bundle.windows.nsis.installMode -ne "currentUser") {
 }
 if ($config.bundle.windows.allowDowngrades -ne $false) {
     throw "Windows installer must reject downgrades"
+}
+$expectedInstallerHooks = "windows/installer-hooks.nsh"
+if ($config.bundle.windows.nsis.installerHooks -ne $expectedInstallerHooks) {
+    throw "NSIS installer must reference $expectedInstallerHooks"
+}
+$installerHooksPath = Join-Path (Split-Path -Parent $configPath) $expectedInstallerHooks
+if (-not (Test-Path -LiteralPath $installerHooksPath -PathType Leaf)) {
+    throw "NSIS installer hooks file is missing: $installerHooksPath"
+}
+$installerHooks = Get-Content -Raw -Encoding UTF8 $installerHooksPath
+if ($installerHooks -notmatch '(?m)^!define SAYALL_MINIMUM_WINDOWS_BUILD 17763$') {
+    throw "NSIS installer minimum Windows build must remain 17763"
+}
+if (
+    $installerHooks -notmatch 'NSIS_HOOK_PREINSTALL' -or
+    $installerHooks -notmatch 'AtLeastBuild' -or
+    $installerHooks -notmatch 'SetErrorLevel 1633' -or
+    $installerHooks -notmatch '(?m)^\s*Quit\s*$'
+) {
+    throw "NSIS installer must reject unsupported Windows versions before copying app files"
+}
+$compatibilitySource = Get-Content -Raw -Encoding UTF8 $compatibilitySourcePath
+if ($compatibilitySource -notmatch 'WindowsVersion::new\(10, 0, 17_763\)') {
+    throw "Runtime and NSIS minimum Windows versions must both remain Windows 10 build 17763"
 }
 
 $installers = @(Get-ChildItem -Path $bundleDirectory -Filter "*-setup.exe" -File)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -229,6 +229,13 @@ fn get_send_input_snapshot(state: tauri::State<'_, AppState>) -> SendInputSnapsh
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    #[cfg(windows)]
+    if let Err(error) = sayall_windows::compatibility::check_current_windows() {
+        sayall_windows::compatibility::show_unsupported_windows_message(error);
+        eprintln!("{error}");
+        return;
+    }
+
     tauri::Builder::default()
         .setup(|app| {
             let settings_path = app.path().app_config_dir()?.join("settings.json");

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -50,6 +50,7 @@
         "languages": ["SimpChinese", "English"],
         "displayLanguageSelector": true,
         "installerIcon": "icons/icon.ico",
+        "installerHooks": "windows/installer-hooks.nsh",
         "uninstallerIcon": "icons/icon.ico",
         "startMenuFolder": "无线麦 SayAll"
       }

--- a/src-tauri/windows/installer-hooks.nsh
+++ b/src-tauri/windows/installer-hooks.nsh
@@ -1,0 +1,11 @@
+!include WinVer.nsh
+
+!define SAYALL_MINIMUM_WINDOWS_BUILD 17763
+
+!macro NSIS_HOOK_PREINSTALL
+  ${IfNot} ${AtLeastBuild} ${SAYALL_MINIMUM_WINDOWS_BUILD}
+    MessageBox MB_ICONSTOP|MB_OK "无线麦 SayAll 需要 Windows 10 1809（内部版本 17763）或更高版本。$\r$\nSayAll requires Windows 10 1809 (build 17763) or later."
+    SetErrorLevel 1633
+    Quit
+  ${EndIf}
+!macroend


### PR DESCRIPTION
## 目标

将 Windows 10 1809（build 17763）从文档声明落实为安装与启动双层门禁。

## 实现

- 在 `sayall-windows` 集中定义最低 Windows 版本、纯逻辑判定和真实系统版本读取。
- Tauri Host 在创建 WebView、BLE、WASAPI 和 Raw Input 资源前拒绝低版本，并显示原生中英文提示。
- 通过 Tauri 官方 NSIS installer hook 在复制应用文件前拒绝低于 build 17763 的系统，返回 1633。
- CI 校验 NSIS hook、退出行为和 Rust/NSIS 门槛值一致。
- 同步 README、TODO、长期架构文档和真机测试手册。

## 验证

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo check --workspace`
- `cargo check -p sayall-windows --target x86_64-pc-windows-msvc`
- `pnpm test`
- `pnpm build`
- `pnpm tauri build --no-bundle`
- `git diff --check`

## 验证边界

当前开发机为 Mac。NSIS hook 的实际编译由 Windows CI 验证；低版本虚拟机、Windows 10 1809、Windows 11 上的安装提示、退出码和直接运行 exe 行为仍为 deferred，不能视为真机通过。