### PR TITLE
test: 固化 Rust 与 TypeScript IPC 契约

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2579,6 +2579,7 @@ dependencies = [
  "futures",
  "sayall-core",
  "serde",
+ "serde_json",
  "thiserror 2.0.20",
  "wasapi",
  "windows 0.62.2",

--- a/TODO.md
+++ b/TODO.md
@@ -10,6 +10,7 @@
 - [x] 补充 RC001/RC003 设备名称与标准 GATT Model Number（2A24）识别，在连接快照和界面中传递型号；无法识别时保持 `unknown` 且不阻断 ATVV。Windows 双型号真机验收仍待完成。
 - [x] 将 RC001 短语音场景作为 JSON 夹具回放，覆盖 40 + 80 字节拆包、20 次极速空会话、20 次完整会话和中断后首个新会话恢复；该回放不代表真实 Windows/RC001 固件验收。
 - [x] 将真实连接阶段、能力与解码采样计数接入 Tauri IPC 和连接页面。
+- [x] 使用同一 JSON 契约夹具验证 Rust 序列化与 TypeScript 接口的 `PlatformSnapshot`、`PairedRemote`、camelCase 字段及 RC001/RC003/unknown 枚举值；Windows WebView 运行时 IPC 仍待验收。
 - [x] 实现显式 WASAPI 输出端点枚举、选择、16 kHz PCM 写入、有界队列和真实 padding 排空代码路径。
 - [x] 实现 RC001/RC003 选择持久化、意外断连指数退避重连和 Windows 睡眠/恢复通知代码路径；真机恢复仍待验收。
 - [x] 在 Windows 主机编译 Tauri NSIS Preview 安装包；Windows CI 已生成并复验绑定精确来源 Commit、SHA-256 和未签名状态的 artifact，安装、升级、卸载与正式签名仍待完成。

--- a/Testing/WindowsRC003Preview.md
+++ b/Testing/WindowsRC003Preview.md
@@ -178,6 +178,13 @@
 
 ## 当前自动化记录
 
+2026-09-02 在 Apple Silicon Mac 上完成 Rust ↔ TypeScript IPC 契约快照验证：
+
+- 同一份 JSON 夹具覆盖完整 `PlatformSnapshot`、嵌套连接/音频/Raw Input 快照，以及 RC001、RC003、unknown 三种 `PairedRemote`；
+- Rust 测试从真实结构序列化并与夹具结构级全等比较，同时拒绝任何 snake_case IPC 字段；
+- TypeScript 测试使用前端接口装载同一夹具，核对枚举白名单、精确字段集合、`remoteModel` 和 `isSupportedCandidate` 的 camelCase 边界；
+- 该结果只证明仓库两端静态类型和序列化契约一致，不证明 Tauri command、Windows WebView、WinRT 或真机运行时数据已经通过。
+
 2026-09-02 在 Apple Silicon Mac 上完成 RC001 协议场景回放：
 
 - 从 `GetSayAll/hardware-simulation@65248499cac7da3ad46cd0c11dca1478f7733255` 的 RC001 短语音场景提取纯 ATVV JSON 夹具，保留 `STREAM_START`、40 + 80 字节音频拆包和 `STREAM_STOP`；

--- a/contracts/ipc/windows-runtime.json
+++ b/contracts/ipc/windows-runtime.json
@@ -1,0 +1,69 @@
+{
+  "platformSnapshot": {
+    "platform": "windows",
+    "windowsApiAvailable": true,
+    "bleScanAvailable": true,
+    "bleVoiceReady": true,
+    "wasapiReady": true,
+    "rawInputReady": true,
+    "sendInputReady": true,
+    "verificationStatus": "fixture-only",
+    "connection": {
+      "phase": "ready",
+      "remoteName": "Xiaomi Bluetooth Remote 2",
+      "remoteModel": "rc001",
+      "capabilities": {
+        "version": 256,
+        "codecs": 1,
+        "interaction": 1,
+        "frameSize": 120,
+        "selectedCodec": 1,
+        "sampleRate": 16000
+      },
+      "voiceState": "idle",
+      "decodedSamples": 240,
+      "generation": 7,
+      "reconnectAttempt": 2,
+      "powerNotificationsAvailable": true,
+      "lastError": null
+    },
+    "audio": {
+      "phase": "ready",
+      "selectedEndpointId": "fixture-endpoint-id",
+      "selectedEndpointName": "Fixture Virtual Cable",
+      "queuedSamples": 80,
+      "submittedSamples": 160,
+      "generation": 4,
+      "lastError": null
+    },
+    "rawInput": {
+      "phase": "ready",
+      "matchedDeviceCount": 1,
+      "rawEventCount": 12,
+      "semanticEdgeCount": 8,
+      "lastButton": "home",
+      "lastIsPressed": true,
+      "lastError": null
+    }
+  },
+  "pairedRemotes": [
+    {
+      "id": "fixture-rc001",
+      "name": "Xiaomi Bluetooth Remote 2",
+      "model": "rc001",
+      "isSupportedCandidate": true
+    },
+    {
+      "id": "fixture-rc003",
+      "name": "Xiaomi Bluetooth Remote 2 Pro",
+      "model": "rc003",
+      "isSupportedCandidate": true
+    },
+    {
+      "id": "fixture-unknown",
+      "name": "Approved Fixture Remote",
+      "model": "unknown",
+      "isSupportedCandidate": true
+    }
+  ]
+}

--- a/crates/sayall-windows/Cargo.toml
+++ b/crates/sayall-windows/Cargo.toml
@@ -10,6 +10,9 @@ sayall-core = { path = "../sayall-core" }
 serde.workspace = true
 thiserror.workspace = true
 
+[dev-dependencies]
+serde_json.workspace = true
+
 [target.'cfg(windows)'.dependencies]
 futures = "0.3"
 wasapi = "0.24"

--- a/crates/sayall-windows/tests/ipc_contract.rs
+++ b/crates/sayall-windows/tests/ipc_contract.rs
@@ -1,0 +1,99 @@
+use sayall_core::{AtvvCapabilities, VoiceSessionState};
+use sayall_windows::raw_input::{RawInputPhase, RawInputSnapshot, RemoteButton};
+use sayall_windows::{
+    AudioPhase, AudioSnapshot, ConnectionPhase, ConnectionSnapshot, PairedRemote, PlatformSnapshot,
+    RemoteModel,
+};
+use serde_json::{json, Value};
+
+#[test]
+fn rust_serialization_matches_the_shared_windows_runtime_contract() {
+    let actual = json!({
+        "platformSnapshot": PlatformSnapshot {
+            platform: "windows".into(),
+            windows_api_available: true,
+            ble_scan_available: true,
+            ble_voice_ready: true,
+            wasapi_ready: true,
+            raw_input_ready: true,
+            send_input_ready: true,
+            verification_status: "fixture-only".into(),
+            connection: ConnectionSnapshot {
+                phase: ConnectionPhase::Ready,
+                remote_name: Some("Xiaomi Bluetooth Remote 2".into()),
+                remote_model: RemoteModel::Rc001,
+                capabilities: Some(AtvvCapabilities {
+                    version: 256,
+                    codecs: 1,
+                    interaction: 1,
+                    frame_size: 120,
+                    selected_codec: 1,
+                    sample_rate: 16_000,
+                }),
+                voice_state: VoiceSessionState::Idle,
+                decoded_samples: 240,
+                generation: 7,
+                reconnect_attempt: 2,
+                power_notifications_available: true,
+                last_error: None,
+            },
+            audio: AudioSnapshot {
+                phase: AudioPhase::Ready,
+                selected_endpoint_id: Some("fixture-endpoint-id".into()),
+                selected_endpoint_name: Some("Fixture Virtual Cable".into()),
+                queued_samples: 80,
+                submitted_samples: 160,
+                generation: 4,
+                last_error: None,
+            },
+            raw_input: RawInputSnapshot {
+                phase: RawInputPhase::Ready,
+                matched_device_count: 1,
+                raw_event_count: 12,
+                semantic_edge_count: 8,
+                last_button: Some(RemoteButton::Home),
+                last_is_pressed: Some(true),
+                last_error: None,
+            },
+        },
+        "pairedRemotes": [
+            PairedRemote {
+                id: "fixture-rc001".into(),
+                name: "Xiaomi Bluetooth Remote 2".into(),
+                model: RemoteModel::Rc001,
+                is_supported_candidate: true,
+            },
+            PairedRemote {
+                id: "fixture-rc003".into(),
+                name: "Xiaomi Bluetooth Remote 2 Pro".into(),
+                model: RemoteModel::Rc003,
+                is_supported_candidate: true,
+            },
+            PairedRemote {
+                id: "fixture-unknown".into(),
+                name: "Approved Fixture Remote".into(),
+                model: RemoteModel::Unknown,
+                is_supported_candidate: true,
+            },
+        ],
+    });
+    let expected: Value =
+        serde_json::from_str(include_str!("../../../contracts/ipc/windows-runtime.json"))
+            .expect("shared IPC contract fixture must be valid JSON");
+
+    assert_no_snake_case_keys(&actual);
+    assert_eq!(actual, expected);
+}
+
+fn assert_no_snake_case_keys(value: &Value) {
+    match value {
+        Value::Object(object) => {
+            for (key, child) in object {
+                assert!(!key.contains('_'), "IPC field must be camelCase: {key}");
+                assert_no_snake_case_keys(child);
+            }
+        }
+        Value::Array(values) => values.iter().for_each(assert_no_snake_case_keys),
+        _ => {}
+    }
+}

--- a/src/lib/ipc-contract.test.ts
+++ b/src/lib/ipc-contract.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import contract from "../../contracts/ipc/windows-runtime.json";
+import type {
+  AudioPhase,
+  ConnectionPhase,
+  PairedRemote,
+  PlatformSnapshot,
+  RawInputPhase,
+  RemoteButton,
+  RemoteModel,
+  VoiceSessionState,
+} from "./bridge";
+
+const connectionPhases = [
+  "idle",
+  "connecting",
+  "discovering",
+  "awaiting_capabilities",
+  "ready",
+  "streaming",
+  "draining",
+  "reconnecting",
+  "suspended",
+  "disconnected",
+  "failed",
+] as const satisfies readonly ConnectionPhase[];
+const voiceStates = ["idle", "streaming", "draining"] as const satisfies readonly VoiceSessionState[];
+const remoteModels = ["rc001", "rc003", "unknown"] as const satisfies readonly RemoteModel[];
+const audioPhases = [
+  "unconfigured",
+  "ready",
+  "streaming",
+  "draining",
+  "failed",
+  "unsupported",
+] as const satisfies readonly AudioPhase[];
+const rawInputPhases = [
+  "stopped",
+  "starting",
+  "ready",
+  "failed",
+  "unsupported",
+] as const satisfies readonly RawInputPhase[];
+const remoteButtons = [
+  "back",
+  "ok",
+  "tv",
+  "home",
+  "right",
+  "left",
+  "down",
+  "up",
+  "menu",
+  "power",
+  "volume_mute",
+  "volume_up",
+  "volume_down",
+] as const satisfies readonly RemoteButton[];
+
+describe("Rust and TypeScript IPC contract", () => {
+  it("loads the shared platform snapshot through the frontend types", () => {
+    const fixture = contract.platformSnapshot;
+    const platformSnapshot: PlatformSnapshot = {
+      ...fixture,
+      connection: {
+        ...fixture.connection,
+        phase: memberOf(fixture.connection.phase, connectionPhases),
+        remoteModel: memberOf(fixture.connection.remoteModel, remoteModels),
+        voiceState: memberOf(fixture.connection.voiceState, voiceStates),
+      },
+      audio: {
+        ...fixture.audio,
+        phase: memberOf(fixture.audio.phase, audioPhases),
+      },
+      rawInput: {
+        ...fixture.rawInput,
+        phase: memberOf(fixture.rawInput.phase, rawInputPhases),
+        lastButton:
+          fixture.rawInput.lastButton === null
+            ? null
+            : memberOf(fixture.rawInput.lastButton, remoteButtons),
+      },
+    };
+
+    expect(platformSnapshot).toEqual(fixture);
+    expectExactKeys(platformSnapshot, [
+      "platform",
+      "windowsApiAvailable",
+      "bleScanAvailable",
+      "bleVoiceReady",
+      "wasapiReady",
+      "rawInputReady",
+      "sendInputReady",
+      "verificationStatus",
+      "connection",
+      "audio",
+      "rawInput",
+    ]);
+    expectExactKeys(platformSnapshot.connection, [
+      "phase",
+      "remoteName",
+      "remoteModel",
+      "capabilities",
+      "voiceState",
+      "decodedSamples",
+      "generation",
+      "reconnectAttempt",
+      "powerNotificationsAvailable",
+      "lastError",
+    ]);
+    expectExactKeys(platformSnapshot.connection.capabilities!, [
+      "version",
+      "codecs",
+      "interaction",
+      "frameSize",
+      "selectedCodec",
+      "sampleRate",
+    ]);
+    expectExactKeys(platformSnapshot.audio, [
+      "phase",
+      "selectedEndpointId",
+      "selectedEndpointName",
+      "queuedSamples",
+      "submittedSamples",
+      "generation",
+      "lastError",
+    ]);
+    expectExactKeys(platformSnapshot.rawInput, [
+      "phase",
+      "matchedDeviceCount",
+      "rawEventCount",
+      "semanticEdgeCount",
+      "lastButton",
+      "lastIsPressed",
+      "lastError",
+    ]);
+    expectNoSnakeCaseKeys(platformSnapshot);
+    expect(platformSnapshot).not.toHaveProperty("connection.remote_model");
+  });
+
+  it("keeps RC001, RC003 and unknown paired-remote models stable", () => {
+    const pairedRemotes: PairedRemote[] = contract.pairedRemotes.map((remote) => ({
+      ...remote,
+      model: memberOf(remote.model, remoteModels),
+    }));
+
+    expect(pairedRemotes.map((remote) => remote.model)).toEqual(["rc001", "rc003", "unknown"]);
+    for (const remote of pairedRemotes) {
+      expectExactKeys(remote, ["id", "name", "model", "isSupportedCandidate"]);
+      expect(remote).not.toHaveProperty("is_supported_candidate");
+    }
+  });
+});
+
+function memberOf<T extends string>(value: string, allowed: readonly T[]): T {
+  expect(allowed).toContain(value);
+  return value as T;
+}
+
+function expectExactKeys(value: object, expectedKeys: string[]): void {
+  expect(Object.keys(value).sort()).toEqual([...expectedKeys].sort());
+}
+
+function expectNoSnakeCaseKeys(value: unknown): void {
+  if (Array.isArray(value)) {
+    value.forEach(expectNoSnakeCaseKeys);
+    return;
+  }
+  if (value === null || typeof value !== "object") {
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    expect(key).not.toContain("_");
+    expectNoSnakeCaseKeys(child);
+  }
+}


### PR DESCRIPTION
## 变更

- 新增共享 Windows runtime JSON 契约夹具
- 用真实 Rust 结构序列化核对 PlatformSnapshot 与 PairedRemote
- 用 TypeScript 接口、枚举白名单和精确字段集合核对同一夹具
- 明确拒绝 snake_case IPC 字段泄漏
- 同步 TODO 与 Windows 测试手册

## 验证

- cargo fmt --all -- --check
- cargo test --workspace
- cargo check --workspace
- cargo check -p sayall-windows --target x86_64-pc-windows-msvc
- pnpm test
- pnpm build
- git diff --check

## 边界

该自动化只证明 Rust 序列化与 TypeScript 静态契约一致，不代表 Windows WebView、Tauri command、WinRT 或真实 RC001/RC003 已完成运行验收。