### PR TITLE
test: add Windows Tauri runtime simulation

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -45,8 +45,24 @@ jobs:
       - name: Check Windows Tauri host
         run: cargo check --workspace
 
+      - name: Build Windows runtime simulation
+        shell: pwsh
+        run: |
+          $env:VITE_SAYALL_RUNTIME_SIMULATION = "1"
+          pnpm build
+          cargo build --release -p sayall-windows-app --features runtime-simulation
+
+      - name: Test Windows Tauri WebView and IPC runtime simulation
+        shell: pwsh
+        timeout-minutes: 3
+        run: ./scripts/test-windows-runtime-simulation.ps1
+
       - name: Build unsigned NSIS preview installer
         run: pnpm tauri build --bundles nsis
+
+      - name: Verify runtime simulation is absent from production build
+        shell: pwsh
+        run: ./scripts/verify-runtime-simulation-isolation.ps1
 
       - name: Verify installer identity and create checksums
         shell: pwsh

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -49,8 +49,7 @@ jobs:
         shell: pwsh
         run: |
           $env:VITE_SAYALL_RUNTIME_SIMULATION = "1"
-          pnpm build
-          cargo build --release -p sayall-windows-app --features runtime-simulation
+          pnpm tauri build --no-bundle --features runtime-simulation
 
       - name: Test Windows Tauri WebView and IPC runtime simulation
         shell: pwsh

--- a/TODO.md
+++ b/TODO.md
@@ -18,7 +18,7 @@
 - [x] 持久化并展示仅保存在本机的每日按键次数、完整语音会话次数和语音采样时长；Windows/RC001/RC003 真实事件计数与升级保留仍待真机验收。
 - [x] 对低于 Windows 10 1809（build 17763）的系统增加 NSIS 安装与应用启动双层拒绝门禁；Windows 10 1809 / Windows 11 提示和安装行为仍待真机验收。
 - [x] 在 Windows CI 对 NSIS Preview 执行 `/S` 当前用户安装、启动存活、`/S` 卸载及设置保留边界验证；该自动化不代替可见安装界面、SmartScreen、Windows 10 1809 或真实用户环境验收。
-- [ ] 在 Windows CI 使用仅测试构建可启用的平台仿真，验证真实 WebView JavaScript → Tauri IPC → Rust command、五页导航、RC001/RC003 扫描、首次 RC001 语音、音频端点、Raw Input、映射、诊断和资源释放闭环；不得把仿真状态表述为真实 Windows API 或硬件通过。
+- [x] 在 Windows CI 使用仅测试构建可启用的平台仿真，验证真实 WebView JavaScript → Tauri IPC → Rust command、五页导航、RC001/RC003 扫描、首次 RC001 语音、音频端点、Raw Input、映射、诊断和资源释放闭环；生产 NSIS 已验证不含仿真入口，该结果不代表真实 Windows API 或硬件通过。
 - [ ] 使用真实 RC001 验证型号识别、BLE 配对、连接、断开、重连和首次语音。
 - [ ] 使用真实 RC003 验证型号识别、BLE 配对、连接、断开、重连和首次语音。
 - [ ] 验证 `STREAM_START → AUDIO → STREAM_STOP` 首次会话完整可用。

--- a/TODO.md
+++ b/TODO.md
@@ -18,6 +18,7 @@
 - [x] 持久化并展示仅保存在本机的每日按键次数、完整语音会话次数和语音采样时长；Windows/RC001/RC003 真实事件计数与升级保留仍待真机验收。
 - [x] 对低于 Windows 10 1809（build 17763）的系统增加 NSIS 安装与应用启动双层拒绝门禁；Windows 10 1809 / Windows 11 提示和安装行为仍待真机验收。
 - [x] 在 Windows CI 对 NSIS Preview 执行 `/S` 当前用户安装、启动存活、`/S` 卸载及设置保留边界验证；该自动化不代替可见安装界面、SmartScreen、Windows 10 1809 或真实用户环境验收。
+- [ ] 在 Windows CI 使用仅测试构建可启用的平台仿真，验证真实 WebView JavaScript → Tauri IPC → Rust command、五页导航、RC001/RC003 扫描、首次 RC001 语音、音频端点、Raw Input、映射、诊断和资源释放闭环；不得把仿真状态表述为真实 Windows API 或硬件通过。
 - [ ] 使用真实 RC001 验证型号识别、BLE 配对、连接、断开、重连和首次语音。
 - [ ] 使用真实 RC003 验证型号识别、BLE 配对、连接、断开、重连和首次语音。
 - [ ] 验证 `STREAM_START → AUDIO → STREAM_STOP` 首次会话完整可用。

--- a/Testing/WindowsRC003Preview.md
+++ b/Testing/WindowsRC003Preview.md
@@ -192,6 +192,16 @@
 
 ## 当前自动化记录
 
+2026-09-02 在 `windows-latest` 完成 Tauri/WebView/IPC 运行时仿真：
+
+- Windows CI Run [`33611750471`](https://github.com/GetSayAll/remote-mic-app-windows/actions/runs/33611750471) 使用 Tauri CLI 构建仅测试 feature 程序，并在真实 Windows WebView 中完成 11 个结构化步骤；
+- WebView JavaScript 通过真实 Tauri IPC 读取仿真快照，渲染 RC001/RC003 扫描结果，连接 RC001、选择仿真 CABLE Input、启动 Raw Input、保存映射并由非注入式 SendInput 记录器验证 Ctrl+C 四事件；
+- 五个侧栏页面均完成导航和挂载，权限页生成平台标记为 `windows-ci-simulation` 的去标识化诊断摘要，统计 IPC 返回最近七天结构；
+- 首次 `STREAM_START → 40 + 80 AUDIO → STREAM_STOP → DRAIN` 通过纯 Rust ATVV 管线得到 240 个采样和 generation 1，随后 Raw Input 与连接状态均完成释放；
+- 同一 Run 重新构建普通 NSIS，二进制和前端资源均确认不含仿真平台名或仿真 command，并继续通过静默安装/卸载回归；
+- Run [`33610428178`](https://github.com/GetSayAll/remote-mic-app-windows/actions/runs/33610428178) 首次暴露直接 `cargo build` 生成开发协议程序会等待 Vite dev server；改为 `tauri build --no-bundle --features runtime-simulation` 后修复；
+- 该结果不访问真实 WinRT BLE、WASAPI、Raw Input 或桌面 SendInput，不代表 RC001/RC003、音质、VB-CABLE 或真实按键已经通过。
+
 2026-09-02 在 `windows-latest` 完成 NSIS 静默安装与卸载生命周期验证：
 
 - Windows CI Run [`33593663937`](https://github.com/GetSayAll/remote-mic-app-windows/actions/runs/33593663937) 从提交 `5f01fa41cfbd15b967a760e490b9343260e768a6` 构建 `无线麦 SayAll_0.1.0_x64-setup.exe`，SHA-256 为 `a9fa2bfbfd519189629abc3ed91d5a811752081452d93c475c62129dd1e16e44`；

--- a/Testing/WindowsRC003Preview.md
+++ b/Testing/WindowsRC003Preview.md
@@ -167,6 +167,19 @@
 
 失败判定：一次实体按键增加多次、语音键进入普通按键统计、中断会话被记为完成、页面只显示进程内计数而重启归零、升级丢失或重复统计、日期跨天错误、统计文件含任何设备或用户内容、统计写入阻塞 BLE/Raw Input 回调而造成语音或按键响应退化。
 
+## 用例十二：Windows Tauri/WebView 运行时仿真
+
+1. 以 `runtime-simulation` Cargo feature 和 `VITE_SAYALL_RUNTIME_SIMULATION=1` 构建专用测试程序；普通构建不得包含仿真前端入口或仿真专用 Tauri command。
+2. 在 `windows-latest` 启动该程序，并设置唯一的运行报告路径；不得向真实桌面发送 SendInput，也不得尝试扫描真实 BLE、音频或 HID 设备。
+3. 由实际 Windows WebView JavaScript 依次通过 Tauri IPC 读取运行快照、渲染 RC001/RC003 扫描结果、连接 RC001、选择仿真 CABLE Input、启动 Raw Input、保存并显式测试 Ctrl+C 映射。
+4. 依次打开按键、统计、权限、关于和连接与语音页面；在权限页生成诊断摘要，确认平台明确标记为 `windows-ci-simulation`。
+5. 通过测试专用 command 驱动纯 Rust ATVV 管线完成首次 `STREAM_START → 40 + 80 AUDIO → STREAM_STOP → DRAIN`，确认得到 240 个采样、generation 为 1、连接和音频均回到 ready。
+6. 停止 Raw Input 并断开，确认最终快照为 `rawInput.phase = stopped` 和 `connection.phase = disconnected`；程序写入报告并自行以成功退出码结束。
+
+预期：真实 Windows WebView、Tauri invoke 和 Rust command 边界完成闭环；五个侧栏页面均能挂载；RC001/RC003 和 IPC camelCase 数据可被 Vue 消费；测试专用 SendInput 只记录批次和事件数，不向桌面注入；普通生产构建经字符串检查不包含仿真平台名称或仿真 command。
+
+失败判定：只调用 Rust 单元测试或浏览器预览而没有启动 Windows Tauri WebView；普通构建能启用仿真；测试误调用真实 BLE/WASAPI/Raw Input/SendInput；WebView 进程存活但没有完成报告；把仿真 240 个采样、就绪状态或页面渲染表述为 RC001/RC003 真机通过。
+
 ## 日志收集
 
 日志不得包含语音内容、识别文字、真实蓝牙地址、完整 HID 路径、窗口标题或个人文档路径。报告应包含 Commit、版本、时间段、Windows 版本和失败步骤。
@@ -174,7 +187,7 @@
 ## 验证边界
 
 - Mac 自动化：前端构建、Rust 核心测试、格式化和静态检查。
-- Windows CI：Windows 编译、自动化测试、当前用户静默安装/启动存活/静默卸载和设置目录保留边界；不包含可见安装界面、SmartScreen、Windows 10 1809、真实硬件或第三方应用验收。
+- Windows CI：Windows 编译、自动化测试、测试专用 Tauri/WebView/IPC 仿真、当前用户静默安装/启动存活/静默卸载和设置目录保留边界；不包含可见安装界面、SmartScreen、Windows 10 1809、真实硬件或第三方应用验收。
 - 用户/维护者：RC001 与 RC003 分别的型号识别、蓝牙、音频、Raw Input、输入法、睡眠和安装升级真机验收。
 
 ## 当前自动化记录

--- a/docs/architecture/windows-tauri-roadmap.md
+++ b/docs/architecture/windows-tauri-roadmap.md
@@ -73,6 +73,8 @@ RC001/RC003 断连由 BLE 工作线程统一清理后进入 2–30 秒指数退�
 Tauri Host 负责应用生命周期、IPC、托盘和窗口，不直接解析 ATVV 或处理音频帧。主程序保持普通用户权限。
 设备专属设置写入本应用自己的 Tauri 配置目录；音频端点同时保存稳定 endpoint ID 与用户选择时的名称，不跨设备同步，也不读取 Windows 默认输出配置。启动恢复必须先验证两者一致。
 
+Tauri command 只依赖宿主内的 `PlatformRuntime` 接口。普通构建唯一实现仍是 `WindowsPlatform`；仅显式启用 `runtime-simulation` feature 且设置专用环境变量的 CI 构建可注入确定性平台。仿真实现复用 `sayall-core` ATVV 管线，并只记录 SendInput，不访问真实 BLE、WASAPI、Raw Input 或桌面输入。仿真专用前端入口和 command 必须从普通生产构建中消失。
+
 ### 3.4 可选高级 Helper
 
 返回、独立音量等 Windows 不稳定提供的 HID usage 单独评估。需要提权的能力必须是可选 Helper，并且失败时不能影响 BLE 语音和可靠按键。

--- a/scripts/test-windows-runtime-simulation.ps1
+++ b/scripts/test-windows-runtime-simulation.ps1
@@ -15,27 +15,42 @@ $reportDirectory = if (-not [string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) {
 $simulationId = [Guid]::NewGuid().ToString('N')
 $reportPath = Join-Path $reportDirectory "sayall-runtime-simulation-$simulationId.json"
 $stateDirectory = Join-Path $reportDirectory "sayall-runtime-simulation-state-$simulationId"
+$stdoutPath = Join-Path $reportDirectory "sayall-runtime-simulation-$simulationId.stdout.log"
+$stderrPath = Join-Path $reportDirectory "sayall-runtime-simulation-$simulationId.stderr.log"
 $env:SAYALL_WINDOWS_RUNTIME_SIMULATION = "1"
 $env:SAYALL_RUNTIME_SIMULATION_REPORT = $reportPath
 $env:SAYALL_RUNTIME_SIMULATION_STATE_DIR = $stateDirectory
 $appProcess = $null
 
+function Write-SimulationProcessLogs {
+    foreach ($path in @($stdoutPath, $stderrPath)) {
+        if (Test-Path -LiteralPath $path -PathType Leaf) {
+            Write-Host "Runtime simulation process log: $path"
+            Get-Content -Encoding UTF8 -LiteralPath $path | Write-Host
+        }
+    }
+}
+
 try {
-    $appProcess = Start-Process -FilePath $appExecutable -PassThru
+    $appProcess = Start-Process -FilePath $appExecutable -PassThru `
+        -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath
     $deadline = [DateTime]::UtcNow.AddSeconds(60)
     while (-not $appProcess.HasExited -and [DateTime]::UtcNow -lt $deadline) {
         Start-Sleep -Milliseconds 250
         $appProcess.Refresh()
     }
     if (-not $appProcess.HasExited) {
+        Write-SimulationProcessLogs
         throw "Windows Tauri/WebView runtime simulation did not finish within 60 seconds"
     }
     if (-not (Test-Path -LiteralPath $reportPath -PathType Leaf)) {
+        Write-SimulationProcessLogs
         throw "Windows runtime simulation did not write its report"
     }
 
     $report = Get-Content -Raw -Encoding UTF8 -LiteralPath $reportPath | ConvertFrom-Json
     if ($appProcess.ExitCode -ne 0) {
+        Write-SimulationProcessLogs
         throw "Windows runtime simulation exited with code $($appProcess.ExitCode): $($report.error)"
     }
     if ($report.passed -ne $true) {

--- a/scripts/test-windows-runtime-simulation.ps1
+++ b/scripts/test-windows-runtime-simulation.ps1
@@ -1,0 +1,75 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+$appExecutable = Join-Path $repositoryRoot "target/release/sayall-windows-app.exe"
+if (-not (Test-Path -LiteralPath $appExecutable -PathType Leaf)) {
+    throw "Windows runtime simulation executable is missing: $appExecutable"
+}
+
+$reportDirectory = if (-not [string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) {
+    $env:RUNNER_TEMP
+} else {
+    [IO.Path]::GetTempPath()
+}
+$simulationId = [Guid]::NewGuid().ToString('N')
+$reportPath = Join-Path $reportDirectory "sayall-runtime-simulation-$simulationId.json"
+$stateDirectory = Join-Path $reportDirectory "sayall-runtime-simulation-state-$simulationId"
+$env:SAYALL_WINDOWS_RUNTIME_SIMULATION = "1"
+$env:SAYALL_RUNTIME_SIMULATION_REPORT = $reportPath
+$env:SAYALL_RUNTIME_SIMULATION_STATE_DIR = $stateDirectory
+$appProcess = $null
+
+try {
+    $appProcess = Start-Process -FilePath $appExecutable -PassThru
+    $deadline = [DateTime]::UtcNow.AddSeconds(60)
+    while (-not $appProcess.HasExited -and [DateTime]::UtcNow -lt $deadline) {
+        Start-Sleep -Milliseconds 250
+        $appProcess.Refresh()
+    }
+    if (-not $appProcess.HasExited) {
+        throw "Windows Tauri/WebView runtime simulation did not finish within 60 seconds"
+    }
+    if (-not (Test-Path -LiteralPath $reportPath -PathType Leaf)) {
+        throw "Windows runtime simulation did not write its report"
+    }
+
+    $report = Get-Content -Raw -Encoding UTF8 -LiteralPath $reportPath | ConvertFrom-Json
+    if ($appProcess.ExitCode -ne 0) {
+        throw "Windows runtime simulation exited with code $($appProcess.ExitCode): $($report.error)"
+    }
+    if ($report.passed -ne $true) {
+        throw "Windows runtime simulation reported failure: $($report.error)"
+    }
+    if ($report.platform -ne "windows-ci-simulation") {
+        throw "Unexpected runtime simulation platform: $($report.platform)"
+    }
+    $steps = @($report.steps)
+    if ($steps.Count -lt 10) {
+        throw "Windows runtime simulation completed only $($steps.Count) verification steps"
+    }
+
+    Write-Host "Verified Windows Tauri/WebView runtime simulation: $($steps.Count) steps"
+    foreach ($step in $steps) {
+        Write-Host "- $step"
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) {
+        @"
+### Windows Tauri/WebView runtime simulation
+
+- actual Windows WebView JavaScript → Tauri IPC → Rust command path: passed
+- RC001/RC003 scan and RC001 16 kHz connection state: passed
+- explicit simulated audio endpoint and Raw Input state: passed
+- mapping persistence and non-injecting SendInput recorder: passed
+- five sidebar pages and diagnostics rendering: passed
+- first `STREAM_START → 40+80 AUDIO → STREAM_STOP → DRAIN`: 240 samples passed
+- disconnect and stop cleanup state: passed
+
+This deterministic simulation does not validate real RC001/RC003 hardware, WinRT BLE notifications, WASAPI sound, Raw Input reports, or real SendInput delivery.
+"@ | Add-Content -Encoding UTF8 $env:GITHUB_STEP_SUMMARY
+    }
+} finally {
+    if ($null -ne $appProcess -and -not $appProcess.HasExited) {
+        Stop-Process -Id $appProcess.Id -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/scripts/verify-runtime-simulation-isolation.ps1
+++ b/scripts/verify-runtime-simulation-isolation.ps1
@@ -1,0 +1,33 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+$productionExecutable = Join-Path $repositoryRoot "target/release/sayall-windows-app.exe"
+$frontendDirectory = Join-Path $repositoryRoot "dist"
+$forbiddenTokens = @(
+    "windows-ci-simulation",
+    "run_runtime_simulation_voice_session",
+    "complete_runtime_simulation_smoke"
+)
+
+$files = @()
+if (Test-Path -LiteralPath $productionExecutable -PathType Leaf) {
+    $files += Get-Item -LiteralPath $productionExecutable
+}
+if (Test-Path -LiteralPath $frontendDirectory -PathType Container) {
+    $files += Get-ChildItem -LiteralPath $frontendDirectory -File -Recurse
+}
+if ($files.Count -lt 2) {
+    throw "Production runtime isolation check could not find the executable and frontend assets"
+}
+
+foreach ($file in $files) {
+    $contents = [Text.Encoding]::UTF8.GetString([IO.File]::ReadAllBytes($file.FullName))
+    foreach ($token in $forbiddenTokens) {
+        if ($contents.Contains($token, [StringComparison]::Ordinal)) {
+            throw "Production build contains runtime simulation token '$token' in $($file.FullName)"
+        }
+    }
+}
+
+Write-Host "Verified production build excludes Windows runtime simulation frontend and commands"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 name = "sayall_windows_app"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
+[features]
+runtime-simulation = []
+
 [build-dependencies]
 tauri-build = { version = "2.4", features = [] }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,10 +11,12 @@ use std::sync::{Arc, RwLock};
 use tauri::Manager;
 
 mod diagnostics;
+mod platform;
 mod settings;
 mod statistics;
 
 use diagnostics::DiagnosticReport;
+use platform::PlatformRuntime;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -25,7 +27,7 @@ struct RuntimeSnapshot {
 
 #[derive(Debug)]
 struct AppState {
-    platform: WindowsPlatform,
+    platform: Arc<dyn PlatformRuntime>,
     settings: SettingsStore,
     button_mappings: RwLock<ButtonMappings>,
     statistics: Arc<StatisticsRuntime>,
@@ -60,7 +62,7 @@ async fn get_usage_statistics(
 async fn scan_paired_remotes(
     state: tauri::State<'_, AppState>,
 ) -> Result<Vec<PairedRemote>, String> {
-    let platform = state.platform.clone();
+    let platform = Arc::clone(&state.platform);
     tauri::async_runtime::spawn_blocking(move || platform.scan_paired_remotes())
         .await
         .map_err(|error| format!("扫描任务失败：{error}"))?
@@ -71,7 +73,7 @@ async fn scan_paired_remotes(
 async fn get_connection_snapshot(
     state: tauri::State<'_, AppState>,
 ) -> Result<ConnectionSnapshot, String> {
-    let platform = state.platform.clone();
+    let platform = Arc::clone(&state.platform);
     tauri::async_runtime::spawn_blocking(move || platform.connection_snapshot())
         .await
         .map_err(|error| format!("读取连接状态失败：{error}"))
@@ -82,7 +84,7 @@ async fn connect_remote(
     device_id: String,
     state: tauri::State<'_, AppState>,
 ) -> Result<ConnectionSnapshot, String> {
-    let platform = state.platform.clone();
+    let platform = Arc::clone(&state.platform);
     let settings = state.settings.clone();
     tauri::async_runtime::spawn_blocking(move || {
         settings.save_selected_remote_id(device_id.clone())?;
@@ -98,7 +100,7 @@ async fn connect_remote(
 async fn disconnect_remote(
     state: tauri::State<'_, AppState>,
 ) -> Result<ConnectionSnapshot, String> {
-    let platform = state.platform.clone();
+    let platform = Arc::clone(&state.platform);
     tauri::async_runtime::spawn_blocking(move || platform.disconnect_remote())
         .await
         .map_err(|error| format!("断开任务失败：{error}"))?
@@ -109,7 +111,7 @@ async fn disconnect_remote(
 async fn list_audio_endpoints(
     state: tauri::State<'_, AppState>,
 ) -> Result<Vec<AudioEndpoint>, String> {
-    let platform = state.platform.clone();
+    let platform = Arc::clone(&state.platform);
     tauri::async_runtime::spawn_blocking(move || platform.list_audio_endpoints())
         .await
         .map_err(|error| format!("枚举音频端点任务失败：{error}"))?
@@ -118,7 +120,7 @@ async fn list_audio_endpoints(
 
 #[tauri::command]
 async fn get_audio_snapshot(state: tauri::State<'_, AppState>) -> Result<AudioSnapshot, String> {
-    let platform = state.platform.clone();
+    let platform = Arc::clone(&state.platform);
     tauri::async_runtime::spawn_blocking(move || platform.audio_snapshot())
         .await
         .map_err(|error| format!("读取音频状态失败：{error}"))
@@ -129,7 +131,7 @@ async fn select_audio_endpoint(
     endpoint_id: String,
     state: tauri::State<'_, AppState>,
 ) -> Result<AudioSnapshot, String> {
-    let platform = state.platform.clone();
+    let platform = Arc::clone(&state.platform);
     let settings = state.settings.clone();
     tauri::async_runtime::spawn_blocking(move || {
         let snapshot = platform
@@ -152,7 +154,7 @@ async fn select_audio_endpoint(
 async fn get_raw_input_snapshot(
     state: tauri::State<'_, AppState>,
 ) -> Result<RawInputSnapshot, String> {
-    let platform = state.platform.clone();
+    let platform = Arc::clone(&state.platform);
     tauri::async_runtime::spawn_blocking(move || platform.raw_input_snapshot())
         .await
         .map_err(|error| format!("读取 Raw Input 状态失败：{error}"))
@@ -160,7 +162,7 @@ async fn get_raw_input_snapshot(
 
 #[tauri::command]
 async fn start_raw_input(state: tauri::State<'_, AppState>) -> Result<RawInputSnapshot, String> {
-    let platform = state.platform.clone();
+    let platform = Arc::clone(&state.platform);
     tauri::async_runtime::spawn_blocking(move || platform.start_raw_input())
         .await
         .map_err(|error| format!("启动 Raw Input 任务失败：{error}"))?
@@ -169,7 +171,7 @@ async fn start_raw_input(state: tauri::State<'_, AppState>) -> Result<RawInputSn
 
 #[tauri::command]
 async fn stop_raw_input(state: tauri::State<'_, AppState>) -> Result<RawInputSnapshot, String> {
-    let platform = state.platform.clone();
+    let platform = Arc::clone(&state.platform);
     tauri::async_runtime::spawn_blocking(move || platform.stop_raw_input())
         .await
         .map_err(|error| format!("停止 Raw Input 任务失败：{error}"))?
@@ -215,7 +217,7 @@ async fn test_button_mapping(
     let ButtonAction::Shortcut { chord } = action else {
         return Err("该按键当前未配置快捷键".to_owned());
     };
-    let platform = state.platform.clone();
+    let platform = Arc::clone(&state.platform);
     tauri::async_runtime::spawn_blocking(move || platform.test_shortcut(chord))
         .await
         .map_err(|error| format!("测试快捷键任务失败：{error}"))?
@@ -227,6 +229,55 @@ fn get_send_input_snapshot(state: tauri::State<'_, AppState>) -> SendInputSnapsh
     state.platform.send_input_snapshot()
 }
 
+#[cfg(feature = "runtime-simulation")]
+#[tauri::command]
+fn run_runtime_simulation_voice_session(
+    state: tauri::State<'_, AppState>,
+) -> Result<PlatformSnapshot, String> {
+    state
+        .platform
+        .run_simulated_voice_session()
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(feature = "runtime-simulation")]
+#[tauri::command]
+fn complete_runtime_simulation_smoke(
+    result: serde_json::Value,
+    app: tauri::AppHandle,
+) -> Result<(), String> {
+    let report_path = std::env::var_os("SAYALL_RUNTIME_SIMULATION_REPORT")
+        .ok_or_else(|| "缺少 Windows CI 仿真报告路径".to_owned())?;
+    let contents = serde_json::to_vec_pretty(&result)
+        .map_err(|error| format!("序列化 Windows CI 仿真报告失败：{error}"))?;
+    std::fs::write(report_path, contents)
+        .map_err(|error| format!("写入 Windows CI 仿真报告失败：{error}"))?;
+    let passed = result
+        .get("passed")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        app.exit(if passed { 0 } else { 1 });
+    });
+    Ok(())
+}
+
+fn create_platform() -> Arc<dyn PlatformRuntime> {
+    #[cfg(feature = "runtime-simulation")]
+    if runtime_simulation_requested() {
+        return Arc::new(platform::SimulatedPlatform::default());
+    }
+
+    Arc::new(WindowsPlatform::default())
+}
+
+#[cfg(feature = "runtime-simulation")]
+fn runtime_simulation_requested() -> bool {
+    std::env::var_os("SAYALL_WINDOWS_RUNTIME_SIMULATION").as_deref()
+        == Some(std::ffi::OsStr::new("1"))
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     #[cfg(windows)]
@@ -236,77 +287,116 @@ pub fn run() {
         return;
     }
 
-    tauri::Builder::default()
-        .setup(|app| {
-            let settings_path = app.path().app_config_dir()?.join("settings.json");
-            let settings = SettingsStore::new(settings_path);
-            let saved_settings = match settings.load() {
-                Ok(settings) => settings,
-                Err(error) => {
-                    eprintln!("{error}");
-                    Default::default()
-                }
-            };
-            let platform = WindowsPlatform::default();
-            let statistics = Arc::new(StatisticsRuntime::new(
-                settings.clone(),
-                platform.usage_counters(),
-            ));
-            let button_mappings = match settings.load_button_mappings() {
-                Ok(mappings) => mappings,
-                Err(error) => {
-                    eprintln!("{error}");
-                    ButtonMappings::default()
-                }
-            };
-
-            #[cfg(windows)]
-            if let (Some(endpoint_id), Some(endpoint_name)) = (
-                saved_settings.audio_endpoint_id,
-                saved_settings.audio_endpoint_name,
-            ) {
-                if let Err(error) = platform.restore_audio_endpoint(endpoint_id, endpoint_name) {
-                    eprintln!("恢复已保存的音频端点失败：{error}");
-                }
+    let builder = tauri::Builder::default().setup(|app| {
+        #[cfg(feature = "runtime-simulation")]
+        let settings_path = if runtime_simulation_requested() {
+            let directory =
+                std::env::var_os("SAYALL_RUNTIME_SIMULATION_STATE_DIR").ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        "缺少 Windows CI 仿真设置目录",
+                    )
+                })?;
+            std::path::PathBuf::from(directory).join("settings.json")
+        } else {
+            app.path().app_config_dir()?.join("settings.json")
+        };
+        #[cfg(not(feature = "runtime-simulation"))]
+        let settings_path = app.path().app_config_dir()?.join("settings.json");
+        let settings = SettingsStore::new(settings_path);
+        let saved_settings = match settings.load() {
+            Ok(settings) => settings,
+            Err(error) => {
+                eprintln!("{error}");
+                Default::default()
             }
-
-            #[cfg(windows)]
-            if let Some(device_id) = saved_settings.selected_remote_id {
-                if let Err(error) = platform.restore_remote(device_id) {
-                    eprintln!("恢复已保存的小米语音遥控器失败：{error}");
-                }
+        };
+        let platform = create_platform();
+        let statistics = Arc::new(StatisticsRuntime::new(
+            settings.clone(),
+            platform.usage_counters(),
+        ));
+        let button_mappings = match settings.load_button_mappings() {
+            Ok(mappings) => mappings,
+            Err(error) => {
+                eprintln!("{error}");
+                ButtonMappings::default()
             }
+        };
 
-            #[cfg(not(windows))]
-            let _ = saved_settings;
+        #[cfg(windows)]
+        if let (Some(endpoint_id), Some(endpoint_name)) = (
+            saved_settings.audio_endpoint_id,
+            saved_settings.audio_endpoint_name,
+        ) {
+            if let Err(error) = platform.restore_audio_endpoint(endpoint_id, endpoint_name) {
+                eprintln!("恢复已保存的音频端点失败：{error}");
+            }
+        }
 
-            app.manage(AppState {
-                platform,
-                settings,
-                button_mappings: RwLock::new(button_mappings),
-                statistics,
-            });
-            Ok(())
-        })
-        .invoke_handler(tauri::generate_handler![
-            get_runtime_snapshot,
-            get_diagnostic_report,
-            get_usage_statistics,
-            scan_paired_remotes,
-            get_connection_snapshot,
-            connect_remote,
-            disconnect_remote,
-            list_audio_endpoints,
-            get_audio_snapshot,
-            select_audio_endpoint,
-            get_raw_input_snapshot,
-            start_raw_input,
-            stop_raw_input,
-            get_button_mappings,
-            save_button_mappings,
-            test_button_mapping,
-            get_send_input_snapshot
-        ])
+        #[cfg(windows)]
+        if let Some(device_id) = saved_settings.selected_remote_id {
+            if let Err(error) = platform.restore_remote(device_id) {
+                eprintln!("恢复已保存的小米语音遥控器失败：{error}");
+            }
+        }
+
+        #[cfg(not(windows))]
+        let _ = saved_settings;
+
+        app.manage(AppState {
+            platform,
+            settings,
+            button_mappings: RwLock::new(button_mappings),
+            statistics,
+        });
+        Ok(())
+    });
+
+    #[cfg(feature = "runtime-simulation")]
+    let builder = builder.invoke_handler(tauri::generate_handler![
+        get_runtime_snapshot,
+        get_diagnostic_report,
+        get_usage_statistics,
+        scan_paired_remotes,
+        get_connection_snapshot,
+        connect_remote,
+        disconnect_remote,
+        list_audio_endpoints,
+        get_audio_snapshot,
+        select_audio_endpoint,
+        get_raw_input_snapshot,
+        start_raw_input,
+        stop_raw_input,
+        get_button_mappings,
+        save_button_mappings,
+        test_button_mapping,
+        get_send_input_snapshot,
+        run_runtime_simulation_voice_session,
+        complete_runtime_simulation_smoke
+    ]);
+    #[cfg(not(feature = "runtime-simulation"))]
+    let builder = builder.invoke_handler(tauri::generate_handler![
+        get_runtime_snapshot,
+        get_diagnostic_report,
+        get_usage_statistics,
+        scan_paired_remotes,
+        get_connection_snapshot,
+        connect_remote,
+        disconnect_remote,
+        list_audio_endpoints,
+        get_audio_snapshot,
+        select_audio_endpoint,
+        get_raw_input_snapshot,
+        start_raw_input,
+        stop_raw_input,
+        get_button_mappings,
+        save_button_mappings,
+        test_button_mapping,
+        get_send_input_snapshot
+    ]);
+
+    builder
         .run(tauri::generate_context!())
         .expect("failed to run SayAll Windows app");
 }

--- a/src-tauri/src/platform.rs
+++ b/src-tauri/src/platform.rs
@@ -1,0 +1,467 @@
+use sayall_windows::raw_input::RawInputSnapshot;
+use sayall_windows::send_input::{KeyChord, SendInputSnapshot};
+use sayall_windows::{
+    AudioEndpoint, AudioSnapshot, ConnectionSnapshot, PairedRemote, PlatformError,
+    PlatformSnapshot, UsageCounters, WindowsPlatform,
+};
+use std::fmt::Debug;
+use std::sync::Arc;
+
+pub trait PlatformRuntime: Debug + Send + Sync {
+    fn usage_counters(&self) -> Arc<UsageCounters>;
+    fn snapshot(&self) -> PlatformSnapshot;
+    fn scan_paired_remotes(&self) -> Result<Vec<PairedRemote>, PlatformError>;
+    fn connection_snapshot(&self) -> ConnectionSnapshot;
+    fn connect_remote(&self, device_id: String) -> Result<ConnectionSnapshot, PlatformError>;
+    fn disconnect_remote(&self) -> Result<ConnectionSnapshot, PlatformError>;
+    #[cfg(windows)]
+    fn restore_remote(&self, device_id: String) -> Result<ConnectionSnapshot, PlatformError>;
+    fn list_audio_endpoints(&self) -> Result<Vec<AudioEndpoint>, PlatformError>;
+    fn select_audio_endpoint(&self, endpoint_id: String) -> Result<AudioSnapshot, PlatformError>;
+    #[cfg(windows)]
+    fn restore_audio_endpoint(
+        &self,
+        endpoint_id: String,
+        expected_name: String,
+    ) -> Result<AudioSnapshot, PlatformError>;
+    fn audio_snapshot(&self) -> AudioSnapshot;
+    fn raw_input_snapshot(&self) -> RawInputSnapshot;
+    fn start_raw_input(&self) -> Result<RawInputSnapshot, PlatformError>;
+    fn stop_raw_input(&self) -> Result<RawInputSnapshot, PlatformError>;
+    fn send_input_snapshot(&self) -> SendInputSnapshot;
+    fn test_shortcut(&self, chord: KeyChord) -> Result<SendInputSnapshot, PlatformError>;
+
+    #[cfg(feature = "runtime-simulation")]
+    fn run_simulated_voice_session(&self) -> Result<PlatformSnapshot, PlatformError> {
+        Err(PlatformError::UnsupportedPlatform)
+    }
+}
+
+impl PlatformRuntime for WindowsPlatform {
+    fn usage_counters(&self) -> Arc<UsageCounters> {
+        self.usage_counters()
+    }
+
+    fn snapshot(&self) -> PlatformSnapshot {
+        self.snapshot()
+    }
+
+    fn scan_paired_remotes(&self) -> Result<Vec<PairedRemote>, PlatformError> {
+        self.scan_paired_remotes()
+    }
+
+    fn connection_snapshot(&self) -> ConnectionSnapshot {
+        self.connection_snapshot()
+    }
+
+    fn connect_remote(&self, device_id: String) -> Result<ConnectionSnapshot, PlatformError> {
+        self.connect_remote(device_id)
+    }
+
+    fn disconnect_remote(&self) -> Result<ConnectionSnapshot, PlatformError> {
+        self.disconnect_remote()
+    }
+
+    #[cfg(windows)]
+    fn restore_remote(&self, device_id: String) -> Result<ConnectionSnapshot, PlatformError> {
+        self.restore_remote(device_id)
+    }
+
+    fn list_audio_endpoints(&self) -> Result<Vec<AudioEndpoint>, PlatformError> {
+        self.list_audio_endpoints()
+    }
+
+    fn select_audio_endpoint(&self, endpoint_id: String) -> Result<AudioSnapshot, PlatformError> {
+        self.select_audio_endpoint(endpoint_id)
+    }
+
+    #[cfg(windows)]
+    fn restore_audio_endpoint(
+        &self,
+        endpoint_id: String,
+        expected_name: String,
+    ) -> Result<AudioSnapshot, PlatformError> {
+        self.restore_audio_endpoint(endpoint_id, expected_name)
+    }
+
+    fn audio_snapshot(&self) -> AudioSnapshot {
+        self.audio_snapshot()
+    }
+
+    fn raw_input_snapshot(&self) -> RawInputSnapshot {
+        self.raw_input_snapshot()
+    }
+
+    fn start_raw_input(&self) -> Result<RawInputSnapshot, PlatformError> {
+        self.start_raw_input()
+    }
+
+    fn stop_raw_input(&self) -> Result<RawInputSnapshot, PlatformError> {
+        self.stop_raw_input()
+    }
+
+    fn send_input_snapshot(&self) -> SendInputSnapshot {
+        self.send_input_snapshot()
+    }
+
+    fn test_shortcut(&self, chord: KeyChord) -> Result<SendInputSnapshot, PlatformError> {
+        self.test_shortcut(chord)
+    }
+}
+
+#[cfg(feature = "runtime-simulation")]
+mod simulation {
+    use super::*;
+    use sayall_core::{AtvvCapabilities, AtvvVoicePipeline, PipelineOutput, VoiceSessionState};
+    use sayall_windows::raw_input::{RawInputPhase, RemoteButton};
+    use sayall_windows::send_input::plan_key_tap;
+    use sayall_windows::{AudioPhase, ConnectionPhase, RemoteModel};
+    use std::sync::{Mutex, MutexGuard};
+
+    const RC001_ID: &str = "ci-simulation-rc001";
+    const RC003_ID: &str = "ci-simulation-rc003";
+    const CABLE_ENDPOINT_ID: &str = "ci-simulation-cable-input";
+    const CABLE_ENDPOINT_NAME: &str = "CABLE Input (CI Simulation)";
+
+    #[derive(Debug)]
+    struct SimulationState {
+        connection: ConnectionSnapshot,
+        audio: AudioSnapshot,
+        raw_input: RawInputSnapshot,
+        send_input: SendInputSnapshot,
+    }
+
+    impl Default for SimulationState {
+        fn default() -> Self {
+            Self {
+                connection: ConnectionSnapshot::default(),
+                audio: AudioSnapshot::default(),
+                raw_input: RawInputSnapshot::default(),
+                send_input: SendInputSnapshot {
+                    available: true,
+                    ..SendInputSnapshot::default()
+                },
+            }
+        }
+    }
+
+    #[derive(Debug, Default)]
+    pub struct SimulatedPlatform {
+        usage: Arc<UsageCounters>,
+        state: Mutex<SimulationState>,
+    }
+
+    impl SimulatedPlatform {
+        fn paired_remotes() -> Vec<PairedRemote> {
+            vec![
+                PairedRemote {
+                    id: RC001_ID.to_owned(),
+                    name: "Xiaomi Bluetooth Remote 2".to_owned(),
+                    model: RemoteModel::Rc001,
+                    is_supported_candidate: true,
+                },
+                PairedRemote {
+                    id: RC003_ID.to_owned(),
+                    name: "Xiaomi Bluetooth Remote 2 Pro".to_owned(),
+                    model: RemoteModel::Rc003,
+                    is_supported_candidate: true,
+                },
+            ]
+        }
+
+        fn audio_endpoints() -> Vec<AudioEndpoint> {
+            vec![AudioEndpoint {
+                id: CABLE_ENDPOINT_ID.to_owned(),
+                name: CABLE_ENDPOINT_NAME.to_owned(),
+                is_virtual_cable_candidate: true,
+            }]
+        }
+
+        fn capabilities() -> AtvvCapabilities {
+            AtvvCapabilities::parse(&[0x0B, 0x01, 0x00, 0x02, 0x03, 0, 120])
+                .expect("CI simulation capabilities are valid")
+        }
+
+        fn connect(&self, device_id: String) -> Result<ConnectionSnapshot, PlatformError> {
+            let remote = Self::paired_remotes()
+                .into_iter()
+                .find(|remote| remote.id == device_id)
+                .ok_or_else(|| PlatformError::Gatt("CI simulation remote is unknown".to_owned()))?;
+            let mut state = lock(&self.state);
+            state.connection = ConnectionSnapshot {
+                phase: ConnectionPhase::Ready,
+                remote_name: Some(remote.name),
+                remote_model: remote.model,
+                capabilities: Some(Self::capabilities()),
+                voice_state: VoiceSessionState::Idle,
+                generation: state.connection.generation,
+                power_notifications_available: true,
+                ..ConnectionSnapshot::default()
+            };
+            Ok(state.connection.clone())
+        }
+    }
+
+    impl PlatformRuntime for SimulatedPlatform {
+        fn usage_counters(&self) -> Arc<UsageCounters> {
+            Arc::clone(&self.usage)
+        }
+
+        fn snapshot(&self) -> PlatformSnapshot {
+            let state = lock(&self.state);
+            PlatformSnapshot {
+                platform: "windows-ci-simulation".to_owned(),
+                windows_api_available: true,
+                ble_scan_available: true,
+                ble_voice_ready: matches!(
+                    state.connection.phase,
+                    ConnectionPhase::Ready | ConnectionPhase::Streaming | ConnectionPhase::Draining
+                ),
+                wasapi_ready: matches!(
+                    state.audio.phase,
+                    AudioPhase::Ready | AudioPhase::Streaming | AudioPhase::Draining
+                ),
+                raw_input_ready: state.raw_input.phase == RawInputPhase::Ready,
+                send_input_ready: state.send_input.available,
+                verification_status:
+                    "Windows CI 仿真只验证 Tauri/WebView/IPC 状态闭环，不代表真实 RC001/RC003、BLE、WASAPI 或 Raw Input 已通过"
+                        .to_owned(),
+                connection: state.connection.clone(),
+                audio: state.audio.clone(),
+                raw_input: state.raw_input.clone(),
+            }
+        }
+
+        fn scan_paired_remotes(&self) -> Result<Vec<PairedRemote>, PlatformError> {
+            Ok(Self::paired_remotes())
+        }
+
+        fn connection_snapshot(&self) -> ConnectionSnapshot {
+            lock(&self.state).connection.clone()
+        }
+
+        fn connect_remote(&self, device_id: String) -> Result<ConnectionSnapshot, PlatformError> {
+            self.connect(device_id)
+        }
+
+        fn disconnect_remote(&self) -> Result<ConnectionSnapshot, PlatformError> {
+            let mut state = lock(&self.state);
+            state.connection = ConnectionSnapshot {
+                phase: ConnectionPhase::Disconnected,
+                generation: state.connection.generation,
+                power_notifications_available: true,
+                ..ConnectionSnapshot::default()
+            };
+            Ok(state.connection.clone())
+        }
+
+        #[cfg(windows)]
+        fn restore_remote(&self, device_id: String) -> Result<ConnectionSnapshot, PlatformError> {
+            self.connect(device_id)
+        }
+
+        fn list_audio_endpoints(&self) -> Result<Vec<AudioEndpoint>, PlatformError> {
+            Ok(Self::audio_endpoints())
+        }
+
+        fn select_audio_endpoint(
+            &self,
+            endpoint_id: String,
+        ) -> Result<AudioSnapshot, PlatformError> {
+            let endpoint = Self::audio_endpoints()
+                .into_iter()
+                .find(|endpoint| endpoint.id == endpoint_id)
+                .ok_or_else(|| {
+                    PlatformError::Audio("CI simulation endpoint is unknown".to_owned())
+                })?;
+            let mut state = lock(&self.state);
+            state.audio = AudioSnapshot {
+                phase: AudioPhase::Ready,
+                selected_endpoint_id: Some(endpoint.id),
+                selected_endpoint_name: Some(endpoint.name),
+                generation: state.audio.generation,
+                ..AudioSnapshot::default()
+            };
+            Ok(state.audio.clone())
+        }
+
+        #[cfg(windows)]
+        fn restore_audio_endpoint(
+            &self,
+            endpoint_id: String,
+            expected_name: String,
+        ) -> Result<AudioSnapshot, PlatformError> {
+            if expected_name != CABLE_ENDPOINT_NAME {
+                return Err(PlatformError::Audio(
+                    "CI simulation endpoint name changed".to_owned(),
+                ));
+            }
+            self.select_audio_endpoint(endpoint_id)
+        }
+
+        fn audio_snapshot(&self) -> AudioSnapshot {
+            lock(&self.state).audio.clone()
+        }
+
+        fn raw_input_snapshot(&self) -> RawInputSnapshot {
+            lock(&self.state).raw_input.clone()
+        }
+
+        fn start_raw_input(&self) -> Result<RawInputSnapshot, PlatformError> {
+            let mut state = lock(&self.state);
+            state.raw_input = RawInputSnapshot {
+                phase: RawInputPhase::Ready,
+                matched_device_count: 1,
+                raw_event_count: 2,
+                semantic_edge_count: 2,
+                last_button: Some(RemoteButton::Ok),
+                last_is_pressed: Some(false),
+                last_error: None,
+            };
+            Ok(state.raw_input.clone())
+        }
+
+        fn stop_raw_input(&self) -> Result<RawInputSnapshot, PlatformError> {
+            let mut state = lock(&self.state);
+            state.raw_input = RawInputSnapshot::default();
+            Ok(state.raw_input.clone())
+        }
+
+        fn send_input_snapshot(&self) -> SendInputSnapshot {
+            lock(&self.state).send_input.clone()
+        }
+
+        fn test_shortcut(&self, chord: KeyChord) -> Result<SendInputSnapshot, PlatformError> {
+            let planned = plan_key_tap(&chord)
+                .map_err(|error| PlatformError::SendInput(error.to_string()))?;
+            let mut state = lock(&self.state);
+            state.send_input.submitted_batches =
+                state.send_input.submitted_batches.saturating_add(1);
+            state.send_input.submitted_events = state
+                .send_input
+                .submitted_events
+                .saturating_add(planned.len() as u64);
+            state.send_input.last_error = None;
+            Ok(state.send_input.clone())
+        }
+
+        fn run_simulated_voice_session(&self) -> Result<PlatformSnapshot, PlatformError> {
+            {
+                let state = lock(&self.state);
+                if state.connection.phase != ConnectionPhase::Ready {
+                    return Err(PlatformError::Protocol(
+                        "CI simulation remote is not ready".to_owned(),
+                    ));
+                }
+                if state.audio.phase != AudioPhase::Ready {
+                    return Err(PlatformError::AudioEndpointNotSelected);
+                }
+            }
+
+            let mut pipeline = AtvvVoicePipeline::default();
+            pipeline
+                .handle_control(&[0x0B, 0x01, 0x00, 0x02, 0x03, 0, 120])
+                .map_err(|error| PlatformError::Protocol(error.to_string()))?;
+            let started = pipeline
+                .handle_control(&[0x04, 0x03, 0x02, 0x01])
+                .map_err(|error| PlatformError::Protocol(error.to_string()))?;
+            let PipelineOutput::StreamStarted { generation, .. } = started else {
+                return Err(PlatformError::Protocol(
+                    "CI simulation stream did not start".to_owned(),
+                ));
+            };
+            let mut decoded_samples = 0u64;
+            for audio in [&[0x11; 40][..], &[0x11; 80][..]] {
+                let output = pipeline
+                    .handle_audio(audio)
+                    .map_err(|error| PlatformError::Protocol(error.to_string()))?;
+                let PipelineOutput::Samples { samples, .. } = output else {
+                    return Err(PlatformError::Protocol(
+                        "CI simulation audio did not decode".to_owned(),
+                    ));
+                };
+                decoded_samples = decoded_samples.saturating_add(samples.len() as u64);
+            }
+            pipeline
+                .handle_control(&[0x00])
+                .map_err(|error| PlatformError::Protocol(error.to_string()))?;
+            pipeline
+                .complete_drain(generation)
+                .map_err(|error| PlatformError::Protocol(error.to_string()))?;
+
+            {
+                let mut state = lock(&self.state);
+                state.connection.phase = ConnectionPhase::Ready;
+                state.connection.voice_state = pipeline.state();
+                state.connection.decoded_samples = state
+                    .connection
+                    .decoded_samples
+                    .saturating_add(decoded_samples);
+                state.connection.generation = generation;
+                state.audio.phase = AudioPhase::Ready;
+                state.audio.queued_samples = 0;
+                state.audio.submitted_samples = state
+                    .audio
+                    .submitted_samples
+                    .saturating_add(decoded_samples);
+                state.audio.generation = generation;
+            }
+            Ok(self.snapshot())
+        }
+    }
+
+    fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+        mutex
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use sayall_windows::send_input::{KeyChord, KeyCode};
+
+        #[test]
+        fn simulation_runs_connection_audio_raw_input_and_send_input_journey() {
+            let platform = SimulatedPlatform::default();
+            assert_eq!(platform.scan_paired_remotes().unwrap().len(), 2);
+            assert_eq!(
+                platform
+                    .connect_remote(RC001_ID.to_owned())
+                    .unwrap()
+                    .remote_model,
+                RemoteModel::Rc001
+            );
+            assert_eq!(
+                platform
+                    .select_audio_endpoint(CABLE_ENDPOINT_ID.to_owned())
+                    .unwrap()
+                    .phase,
+                AudioPhase::Ready
+            );
+            assert_eq!(
+                platform.start_raw_input().unwrap().phase,
+                RawInputPhase::Ready
+            );
+            let send_input = platform
+                .test_shortcut(KeyChord {
+                    keys: vec![KeyCode::LeftControl, KeyCode::C],
+                })
+                .unwrap();
+            assert_eq!(send_input.submitted_batches, 1);
+            assert_eq!(send_input.submitted_events, 4);
+
+            let snapshot = platform.run_simulated_voice_session().unwrap();
+            assert_eq!(snapshot.connection.decoded_samples, 240);
+            assert_eq!(snapshot.connection.voice_state, VoiceSessionState::Idle);
+            assert_eq!(snapshot.audio.submitted_samples, 240);
+            assert!(snapshot.ble_voice_ready);
+            assert!(snapshot.wasapi_ready);
+            assert!(snapshot.raw_input_ready);
+            assert!(snapshot.send_input_ready);
+        }
+    }
+}
+
+#[cfg(feature = "runtime-simulation")]
+pub use simulation::SimulatedPlatform;

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,3 +3,9 @@ import App from "./App.vue";
 import "./styles.css";
 
 createApp(App).mount("#app");
+
+if (import.meta.env.VITE_SAYALL_RUNTIME_SIMULATION === "1") {
+  void import("./runtime-simulation").then(({ runRuntimeSimulationSmoke }) =>
+    runRuntimeSimulationSmoke(),
+  );
+}

--- a/src/runtime-simulation.ts
+++ b/src/runtime-simulation.ts
@@ -1,0 +1,174 @@
+import { invoke } from "@tauri-apps/api/core";
+import {
+  connectRemote,
+  disconnectRemote,
+  getDiagnosticReport,
+  getRuntimeSnapshot,
+  getUsageStatistics,
+  listAudioEndpoints,
+  saveButtonMappings,
+  scanPairedRemotes,
+  selectAudioEndpoint,
+  startRawInput,
+  stopRawInput,
+  testButtonMapping,
+  type PlatformSnapshot,
+} from "./lib/bridge";
+
+interface RuntimeSimulationReport {
+  passed: boolean;
+  platform?: string;
+  steps: string[];
+  error?: string;
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+async function waitFor<T>(read: () => T | null, description: string): Promise<T> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    const value = read();
+    if (value !== null) return value;
+    await new Promise((resolve) => window.setTimeout(resolve, 50));
+  }
+  throw new Error(`等待 ${description} 超时`);
+}
+
+function buttonWithText(label: string): HTMLButtonElement | null {
+  return (
+    Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find(
+      (button) => button.textContent?.trim().includes(label) && !button.disabled,
+    ) ?? null
+  );
+}
+
+async function clickButton(label: string): Promise<void> {
+  const button = await waitFor(() => buttonWithText(label), `按钮“${label}”可用`);
+  button.click();
+}
+
+async function openPage(label: string, heading = label): Promise<void> {
+  const button = await waitFor(
+    () =>
+      Array.from(document.querySelectorAll<HTMLButtonElement>("nav button")).find(
+        (candidate) => candidate.textContent?.trim().includes(label),
+      ) ?? null,
+    `导航“${label}”`,
+  );
+  button.click();
+  await waitFor(
+    () => (document.querySelector("h1")?.textContent?.trim() === heading ? heading : null),
+    `页面“${heading}”`,
+  );
+}
+
+async function runJourney(steps: string[]): Promise<PlatformSnapshot> {
+  await waitFor(
+    () => (document.querySelector("h1")?.textContent?.trim() === "连接与语音" ? true : null),
+    "连接与语音首页",
+  );
+  const runtime = await getRuntimeSnapshot();
+  assert(runtime.platform.platform === "windows-ci-simulation", "应用未使用 Windows CI 仿真后端");
+  steps.push("Tauri WebView 通过真实 IPC 读取仿真运行快照");
+
+  await clickButton("扫描已配对设备");
+  await waitFor(
+    () => (document.body.textContent?.includes("找到 2 个已批准名称的候选设备") ? true : null),
+    "RC001/RC003 扫描结果",
+  );
+  const remotes = await scanPairedRemotes();
+  assert(remotes.length === 2, "仿真扫描没有同时返回 RC001 和 RC003");
+  assert(remotes.some((remote) => remote.model === "rc001"), "仿真扫描缺少 RC001");
+  assert(remotes.some((remote) => remote.model === "rc003"), "仿真扫描缺少 RC003");
+  steps.push("连接页面渲染 RC001/RC003 扫描结果");
+
+  const rc001 = remotes.find((remote) => remote.model === "rc001");
+  assert(rc001, "找不到 RC001 仿真设备");
+  const connection = await connectRemote(rc001.id);
+  assert(connection.phase === "ready", "RC001 仿真连接没有进入 ATVV 就绪");
+  assert(connection.capabilities?.sampleRate === 16_000, "RC001 仿真能力不是 16 kHz");
+  steps.push("RC001 连接 command 返回 16 kHz ATVV 就绪状态");
+
+  await clickButton("读取输出端点");
+  await waitFor(
+    () => (document.body.textContent?.includes("CABLE Input (CI Simulation)") ? true : null),
+    "仿真音频端点",
+  );
+  const endpoints = await listAudioEndpoints();
+  assert(endpoints.length === 1, "仿真音频端点数量异常");
+  const audio = await selectAudioEndpoint(endpoints[0].id);
+  assert(audio.phase === "ready", "仿真音频端点没有进入 WASAPI 就绪");
+  steps.push("连接页面和 IPC 完成显式音频端点选择");
+
+  await openPage("按键");
+  await clickButton("启动监听");
+  await waitFor(() => (buttonWithText("停止监听") ? true : null), "Raw Input 就绪状态");
+  const rawInput = await startRawInput();
+  assert(rawInput.phase === "ready", "仿真 Raw Input 没有进入就绪");
+  assert(rawInput.semanticEdgeCount === 2, "仿真 Raw Input 语义边沿数量异常");
+  steps.push("按键页面通过 IPC 启动并展示 Raw Input 仿真状态");
+
+  await saveButtonMappings({
+    actions: {
+      ok: { type: "shortcut", chord: { keys: ["left_control", "c"] } },
+    },
+  });
+  const sendInput = await testButtonMapping("ok");
+  assert(sendInput.submittedBatches === 1, "仿真 SendInput 没有提交唯一批次");
+  assert(sendInput.submittedEvents === 4, "Ctrl+C 仿真没有生成四个按下/释放事件");
+  steps.push("映射保存、热加载和 SendInput 记录器通过真实 Tauri IPC");
+
+  await openPage("统计");
+  const statistics = await getUsageStatistics();
+  assert(statistics.recentDays.length === 7, "统计 IPC 没有返回最近七天结构");
+  steps.push("统计页面和统计 IPC 在 Windows WebView 运行时可用");
+
+  await openPage("权限");
+  await clickButton("生成摘要");
+  await waitFor(
+    () =>
+      document.querySelector(".diagnostic-output")?.textContent?.includes("windows-ci-simulation")
+        ? true
+        : null,
+    "诊断摘要渲染",
+  );
+  const diagnostic = await getDiagnosticReport();
+  assert(diagnostic.platform === "windows-ci-simulation", "诊断摘要没有来自仿真平台");
+  assert(diagnostic.capabilities.bleVoiceReady, "诊断摘要没有反映 ATVV 就绪");
+  assert(diagnostic.capabilities.wasapiReady, "诊断摘要没有反映 WASAPI 就绪");
+  assert(diagnostic.capabilities.rawInputReady, "诊断摘要没有反映 Raw Input 就绪");
+  steps.push("权限页面生成去标识化运行诊断摘要");
+
+  await openPage("关于");
+  await openPage("连接与语音");
+  steps.push("五个侧栏页面均在 Windows WebView 中完成导航和渲染");
+
+  const voice = await invoke<PlatformSnapshot>("run_runtime_simulation_voice_session");
+  assert(voice.connection.decodedSamples === 240, "40 + 80 字节语音没有解码为 240 个采样");
+  assert(voice.connection.generation === 1, "首次仿真语音会话代次不是 1");
+  assert(voice.connection.voiceState === "idle", "仿真语音排空后没有回到 idle");
+  assert(voice.audio.submittedSamples === 240, "仿真 WASAPI 没有提交完整 240 个采样");
+  steps.push("RC001 首次 STREAM_START → 40+80 AUDIO → STREAM_STOP → DRAIN 闭环完成");
+
+  await stopRawInput();
+  await disconnectRemote();
+  const finalSnapshot = await getRuntimeSnapshot();
+  assert(finalSnapshot.platform.connection.phase === "disconnected", "仿真连接没有释放");
+  assert(finalSnapshot.platform.rawInput.phase === "stopped", "仿真 Raw Input 没有停止");
+  steps.push("断开和停止 command 完成资源状态释放");
+  return voice;
+}
+
+export async function runRuntimeSimulationSmoke(): Promise<void> {
+  const report: RuntimeSimulationReport = { passed: false, steps: [] };
+  try {
+    const snapshot = await runJourney(report.steps);
+    report.passed = true;
+    report.platform = snapshot.platform;
+  } catch (error) {
+    report.error = error instanceof Error ? error.message : String(error);
+  }
+  await invoke("complete_runtime_simulation_smoke", { result: report });
+}


### PR DESCRIPTION
## 目标\n\n为 Windows 版建立仅测试构建可启用的平台仿真，并在 GitHub Windows Runner 上启动真实 Tauri WebView，验证 JavaScript → IPC → Rust command 闭环。\n\n## 变更\n\n- Tauri Host 通过 PlatformRuntime 接口注入正式 WindowsPlatform 或 feature-gated SimulatedPlatform\n- 仿真复用 sayall-core ATVV 管线，覆盖 RC001/RC003 扫描、RC001 首次 40+80 字节语音、音频端点、Raw Input 和非注入式 SendInput 记录\n- Windows WebView 自动导航五个页面、生成诊断、验证设置/映射 IPC，并写出结构化报告后退出\n- CI 在仿真后重新构建生产 NSIS，并拒绝生产前端或可执行文件包含仿真 command/token\n- 同步架构说明、TODO 和 Windows 测试手册\n\n## 本地验证\n\n- cargo fmt --all -- --check\n- cargo test --workspace\n- cargo test -p sayall-windows-app --features runtime-simulation\n- cargo check --workspace --all-features\n- pnpm test\n- pnpm build\n- pnpm tauri build --no-bundle\n- 生产 dist 不含仿真平台和 command 字符串\n\n## 边界\n\n本 PR 不访问真实 BLE、WASAPI、Raw Input 或 SendInput，不代表 RC001/RC003 或 Windows 真机路径已通过。