### PR TITLE
fix: make Windows Tauri development startup reliable

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,9 @@ export default defineConfig({
   server: {
     port: 2430,
     strictPort: true,
+    watch: {
+      ignored: ["**/target/**"],
+    },
   },
   envPrefix: ["VITE_", "TAURI_"],
 });


### PR DESCRIPTION
## 原因

在全新的 Windows 开发环境执行 `pnpm tauri dev` 时发现两个可复现问题：

1. Vite 会递归监听 Rust 的 `target` 目录。Cargo 链接并锁定 `sayall_windows_app.dll` 时，Node 文件监听器会抛出 `EBUSY`，导致前端开发服务器退出，Tauri 无法完成启动。
2. 当前 pnpm 供应链策略默认拒绝依赖安装脚本。项目没有显式记录允许构建 `esbuild`，因此新的 checkout 会在依赖检查阶段失败。

## 修复

- 在 Vite dev server 配置中忽略 `**/target/**`，隔离 Rust 构建产物与前端文件监听。
- 新增最小 `pnpm-workspace.yaml`，只允许 `esbuild` 执行构建脚本，不放宽其他依赖。

## 验证

- `pnpm test`：11 passed
- `pnpm build`：passed
- `cargo test --workspace`：67 passed
- `cargo fmt --all -- --check`：passed
- `pnpm tauri dev`：原生窗口成功启动并保持响应
- 五页导航与按键映射交互烟测通过，浏览器控制台无 error/warn

本 PR 不宣称 RC001、RC003 或 VB-CABLE 真机链路已经验收。