### PR TITLE
fix: session-activate WeType before voice hotkey injection

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -27,6 +27,7 @@
 - **WeType/微信输入法语音快捷键形态**：默认按住 Ctrl+Win（微信电脑版 4.1.7+ 同款，可于微信"设置→快捷键"自定义；新浪财经/光明网/callmysoft 报道）；社区帖（linux.do/t/topic/2409202，2026-06-15，早于 2.1.3，引自搜索摘要）称 WeType 语音快捷键"必须以 Ctrl/Alt/Shift 开头，不能设独立单键"——**待 2.1.3 真机复核**；ghxi 评论区提到"单击 Ctrl 触发"模式（懒加载未复核）。讯飞输入法 PC 版默认 F6 单键+长按说话（pconline/3DM/ghxi 教程）——竞品基线，未实测其延迟。
 - **竞品/社区对"面板出现延迟"的讨论**：未找到任何量化"按下→微信电平图出现"的公开评测（横评均测识别速度/准确率）；游戏侧有 PTT 激活延迟 1s-5s 的社区案例（Overwatch 官方论坛、Valorant Reddit），第三方全局钩子（如 Razer Synapse）可使 PTT 延迟 3-5s——排查本机钩子干扰的依据。
 - **本专项实测结论（evidence/p，2026-09-05）**：注入→WeType 开麦（ConsentStore 精确 FILETIME 判据）稳定 ~163ms（13 试验 ±5ms），端点预热无效；两型号遥控器实际均直接 0x04 开始推流（历史 GATT 日志 0x08 计数为 0，无可并行的开麦往返）；0x04 通知早于 HID F5 键盘事件 60-90ms 到达（evidence/p 2026-09-04 取证），当前"0x04 到达即注入"已是链路最早合法触发点。剩余 ~215-245ms = BLE/固件（~30-60ms）+ 和弦间隔（20ms）+ WeType 内部处理（~163ms，外部不可合法压缩）。
+- **macOS 版输入目的地/输入源设计（HD838A/remote-mic-app，本机 clone `Documents\Codex\remote-mic-app`）**：`VoiceInputDestinationCoordinator.swift`——语音触发由"聚焦目的地就绪"门控（AX 系统级聚焦快照：role ∈ {AXTextArea/AXTextField/AXComboBox} + enabled + editable + 非保护内容 + 语义文本不含 password/search/设置 等敏感词；不就绪 UI 提示等待/不可用，5s 超时不注入）；`PreferredInputSourceMonitor`——保证配置的语音工具是活动输入源。**Windows 版 IME 专项（2026-09-05）借鉴其输入源职责**：实测 WeType 语音热键仅在自身为会话活动输入法时生效（微软拼音活跃 2/2 不触发、切回 2/2 恢复、激活后零延迟注入 3/3 触发，evidence/p），已实现 `ime.rs`（TSF `ActivateProfile` + `TF_IPPMF_FORSESSION` 会话级激活，公开 API，失败不阻断）。macOS 的 AX 聚焦目的地门控在 Windows 未采用——焦点实验证明 WeType 开麦不依赖文本焦点（6/6，桌面/资源管理器照常触发），聚焦门控留给未来 UIA 版本按需评估。
 
 ## BLE 僵死链路自动恢复调研来源（2026-09-05，重连健壮性专项）
 

--- a/TODO.md
+++ b/TODO.md
@@ -44,3 +44,7 @@
 
 - **BLE 僵死链路自动恢复（bluetooth_radio.rs，新增）**：应用被强杀后 OS 侧 GATT/HID 链路或服务缓存可能僵死，普通重试永不恢复（真机取证 + Qt 论坛同结论：关开蓝牙是唯一有效公开 API 手段）。重连循环连续失败 5 次（约 60s）自动关开蓝牙无线电一次（Off→2s→On），每僵死周期最多 2 次防抖动，UI 提示全程可见；WinRT Radio API 未打包进程可用、无需提权（真机验证：开关周期后重连立即成功）。详见 docs\investigations\evidence\p\FINDINGS.md 2026-09-05 节与 ATTRIBUTION.md BLE 恢复调研来源。
 - 语音键 F5 抑制器补防粘键配对（VVC 同款"DOWN 漏进 OS 则 UP 必放行"）：按下沿 60ms 有界等待超时泄漏时，释放沿放行，杜绝"F5 粘住→和弦全部被拒"的整机失效模式。
+
+### 2026-09-05 IME 专项
+
+- **语音"无法唤起"根因 = 会话活动输入法不是微信输入法**（WeType 语音热键仅在自身活跃时生效；焦点无关，桌面/资源管理器聚焦 6/6 照常开麦）。修复（ime.rs）：注入和弦前用公开 TSF API 会话级激活 WeType（TF_IPPMF_FORSESSION，零延迟 3/3 实证），失败不阻断。参考 macOS 版 PreferredInputSourceMonitor 职责设计。

--- a/crates/sayall-windows/Cargo.toml
+++ b/crates/sayall-windows/Cargo.toml
@@ -26,10 +26,12 @@ windows = { version = "0.62", features = [
     "Storage_Streams",
     "Win32_Foundation",
     "Win32_Graphics_Gdi",
+    "Win32_System_Com",
     "Win32_System_Power",
     "Win32_System_LibraryLoader",
     "Win32_System_WinRT",
     "Win32_UI_Input",
     "Win32_UI_Input_KeyboardAndMouse",
+    "Win32_UI_TextServices",
     "Win32_UI_WindowsAndMessaging",
 ] }

--- a/crates/sayall-windows/src/ble.rs
+++ b/crates/sayall-windows/src/ble.rs
@@ -867,6 +867,13 @@ fn handle_control(
             // 按住说话快捷键（参考 ZSTDJan/Voice_VibeCoding）：先注入快捷键
             // DOWN，再开始音频会话；注入失败直接中止本次会话并统一释放。
             if let Some(chord) = lock(voice_hold_hotkey).clone() {
+                // 会话级激活微信输入法：其语音热键只在自身为当前会话活动
+                // 输入法时生效（2026-09-05 持锁实验，evidence/p）；激活后零
+                // 延迟注入 3/3 触发，不增加按键延迟。失败仅记录提示，按原
+                // 行为注入（不比现状更差）。
+                if let Err(error) = crate::ime::activate_wetype_session() {
+                    lock(state).last_error = Some(error);
+                }
                 if let Err(error) = send_input.press(&chord) {
                     abort_voice_session(
                         session,

--- a/crates/sayall-windows/src/ime.rs
+++ b/crates/sayall-windows/src/ime.rs
@@ -1,0 +1,58 @@
+//! 微信输入法（WeType）会话级激活。
+//!
+//! 背景（2026-09-05 持锁实验实锤，Testing\investigation\p-ime-experiment.ps1
+//! 与 p-ime-zerodelay.ps1，判据 = ConsentStore 开麦时间戳）：
+//! - WeType 的语音热键（Ctrl+Win）**只有当 WeType 是当前会话的活动输入法时
+//!   才生效**：会话切到微软拼音时注入和弦 2/2 不开麦，切回 WeType 后 2/2
+//!   恢复触发。
+//! - Windows 按应用记忆输入法——用户在其他应用用过微软拼音/豆包/英文后，
+//!   这些应用的会话里 WeType 不活跃，语音键表现为"无法唤起"。
+//! - 与输入框聚焦无关（对照实验：桌面/资源管理器聚焦时 6/6 照常触发，
+//!   p-focus-experiment.ps1）。
+//!
+//! 方案（参考 macOS 版 PreferredInputSourceMonitor 的"保证语音工具是活动
+//! 输入源"职责设计）：注入和弦前，用公开 TSF API
+//! （ITfInputProcessorProfileMgr::ActivateProfile + TF_IPPMF_FORSESSION
+//! 会话级标志——只影响当前应用会话，不改其他应用的输入法记忆）把 WeType
+//! 激活为当前会话输入法。实测：激活后**零延迟**立即注入 3/3 触发（无
+//! settling 等待，不增加按键延迟）。
+//!
+//! 护栏：激活失败只记录提示并按原行为注入（绝不比现状更差）；幂等——
+//! WeType 已活跃时重复激活无害；仅在配置了按住说话快捷键的语音会话上调用。
+
+use windows::core::GUID;
+use windows::Win32::System::Com::{CoCreateInstance, CLSCTX_INPROC_SERVER};
+use windows::Win32::UI::Input::KeyboardAndMouse::HKL;
+use windows::Win32::UI::TextServices::{
+    ITfInputProcessorProfileMgr, TF_IPPMF_FORSESSION, TF_PROFILETYPE_INPUTPROCESSOR,
+};
+
+/// TF_InputProcessorProfiles（msctf.dll，公开 COM 类）。
+const CLSID_TF_INPUT_PROCESSOR_PROFILES: GUID =
+    GUID::from_u128(0x33c53a50_f456_4884_b049_85fd643e_cfed);
+
+/// 微信输入法（WeType）的 TSF CLSID 与 Profile GUID（公开稳定标识；
+/// 来自本机输入法列表 `0804:{86598FB9-…}{607FDF85-…}`，2.1.3.18 实测）。
+const WETYPE_CLSID: GUID = GUID::from_u128(0x86598fb9_66a2_463e_b9c2_aeb906d477ad);
+const WETYPE_PROFILE: GUID = GUID::from_u128(0x607fdf85_fcc8_4dbd_a365_41296f980c9c);
+const LANGID_ZH_CN: u16 = 0x0804;
+
+/// 把微信输入法激活为当前会话的活动输入法（幂等，约 1ms）。
+/// 返回 Err 时调用方记录提示后仍按原行为注入——激活失败不阻断语音。
+pub fn activate_wetype_session() -> Result<(), String> {
+    unsafe {
+        let manager: ITfInputProcessorProfileMgr =
+            CoCreateInstance(&CLSID_TF_INPUT_PROCESSOR_PROFILES, None, CLSCTX_INPROC_SERVER)
+                .map_err(|error| format!("创建 TSF 配置管理器失败：{error}"))?;
+        manager
+            .ActivateProfile(
+                TF_PROFILETYPE_INPUTPROCESSOR,
+                LANGID_ZH_CN,
+                &WETYPE_CLSID,
+                &WETYPE_PROFILE,
+                HKL::default(),
+                TF_IPPMF_FORSESSION,
+            )
+            .map_err(|error| format!("激活微信输入法会话失败：{error}"))
+    }
+}

--- a/crates/sayall-windows/src/lib.rs
+++ b/crates/sayall-windows/src/lib.rs
@@ -13,6 +13,8 @@ mod ble;
 mod bluetooth_radio;
 pub mod compatibility;
 #[cfg(windows)]
+mod ime;
+#[cfg(windows)]
 mod key_suppressor;
 #[cfg(windows)]
 mod power;


### PR DESCRIPTION
## 问题

用户报障：经常出现语音无法唤起。用户怀疑输入框未聚焦，参考 macOS 原版处理。

## 实验结论（持锁，ConsentStore 开麦为判据）

| 条件 | 结果 |
|---|---|
| 桌面 / 资源管理器聚焦（无输入框） | 6/6 照常开麦 → **焦点假设否定** |
| 微信输入法为当前会话活动输入法 | 2/2 触发 |
| 切到微软拼音后注入 | **2/2 不触发** → **根因实锤** |
| 错误状态下先切回微信输入法再注入 | 2/2 恢复 |
| 激活后零延迟立即注入 | 3/3 触发 → **修复不加按键延迟** |

根因：WeType 语音热键（Ctrl+Win）只在自身为当前应用会话活动输入法时生效；Windows 按应用记忆输入法，用户在其他应用切走过输入法后回来按语音键即失败。

## 修复

参考 macOS 原版 \PreferredInputSourceMonitor\（保证语音工具是活动输入源）职责：注入和弦前，以公开 TSF API（\ITfInputProcessorProfileMgr::ActivateProfile\ + \TF_IPPMF_FORSESSION\，约 1ms、幂等、会话级——不影响其他应用的输入法记忆）激活微信输入法；失败仅记录提示、按原行为注入（绝不比现状更差）。

## 验证

- 新增：\crates/sayall-windows/src/ime.rs\；\le.rs\ 注入点接入
- cargo test --workspace 73 个测试全过
- 本机已部署实测；遥控器真机验收待用户确认（RC001/RC003 分别验收后才能宣称通过）