### PR TITLE
ci: 纯文档改动不触发流水线 + 本地 CI 前置自检脚本

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -3,7 +3,21 @@ name: Windows CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'Testing/**'
+      - 'artifacts/**'
+      - '.gitignore'
+      - 'LICENSE'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'Testing/**'
+      - 'artifacts/**'
+      - '.gitignore'
+      - 'LICENSE'
 
 permissions:
   contents: read

--- a/BRANCH_MANAGEMENT.md
+++ b/BRANCH_MANAGEMENT.md
@@ -24,6 +24,11 @@
   CI verify 连续 10 次失败（run #64-#73），阻塞 PR #19 合入近一天才发现。
   发现漂移先 `cargo fmt` 并作为独立 style 提交；CI 全量流水线约 19 分钟，
   格式问题拖到 CI 才暴露反馈太慢。
+- **push 前跑 `scripts/ci-preflight.ps1`（2026-09-05 新增）**：本地镜像 CI
+  verify 的前 6 个快速步骤（前端依赖/测试/构建 + fmt/Rust 测试/check），
+  约 1-2 分钟；通过即等价于 CI 的这些步骤必过。发布前加 `-Full` 追加
+  runtime-simulation 构建。纯文档/非功能改动（**.md、docs/、Testing/、
+  artifacts/）不触发 CI（workflow paths-ignore）。
 - 每个独立工作项一个 commit，只包含该工作项的内容；交付时报告完整 SHA、
   Push 状态与验证命令（引用 macOS 原版"worktree、提交和清理"不变量）。
 - 工作必须中途暂停或移交时：先在功能分支上 commit，并在提交信息中注明

--- a/scripts/ci-preflight.ps1
+++ b/scripts/ci-preflight.ps1
@@ -1,0 +1,108 @@
+﻿# CI 前置自检：在本地跑通 CI verify 的快速检查步骤，通过后再 push。
+#
+# 背景（2026-09-05）：CI verify 曾因 rustfmt 格式漂移连续 10 次失败（run
+# #64-#73），而 CI 全量流水线约 19 分钟，反馈太慢。本脚本镜像 CI 的前
+# 6 个快速步骤（约 1-2 分钟），失败时按 CI 步骤名报告——本地过 = CI
+# 的这些步骤必过（同一命令、同一仓库根）。
+#
+# 用法（仓库根目录）：
+#   powershell -File scripts\ci-preflight.ps1           # 快速检查（推荐每次 push 前）
+#   powershell -File scripts\ci-preflight.ps1 -Full     # 追加 runtime-simulation Tauri 构建（慢，发布前用）
+#
+# 说明：CI 后续的重型步骤（NSIS 安装包、安装矩阵测试）本地不镜像——
+# 它们依赖 CI 环境且极少因常规改动失败；快速步骤通过后 CI 失败的概率
+# 已大幅降低。
+param(
+    [switch]$Full
+)
+
+$ErrorActionPreference = 'Stop'
+try { [Console]::OutputEncoding = [System.Text.Encoding]::UTF8 } catch {}
+
+$repo = Split-Path -Parent $PSScriptRoot
+Set-Location $repo
+
+# ---- pnpm 解析：优先 PATH 上的 pnpm；退化到 corepack pnpm（免全局安装） ----
+$script:UseCorepack = $false
+function Test-PnpmAvailable {
+    if (Get-Command pnpm -ErrorAction SilentlyContinue) { return $true }
+    if (Get-Command corepack -ErrorAction SilentlyContinue) {
+        $script:UseCorepack = $true
+        return $true
+    }
+    return $false
+}
+function Invoke-Pnpm {
+    param([string[]]$PnpmArgs)
+    if ($script:UseCorepack) {
+        & corepack pnpm @PnpmArgs
+    } else {
+        & pnpm @PnpmArgs
+    }
+}
+
+$failures = @()
+$step = 0
+
+function Invoke-Step {
+    param([string]$Name, [scriptblock]$Action)
+    $script:step++
+    Write-Host ("[$script:step/$(if ($Full) { 7 } else { 6 })] $Name ...")
+    & $Action
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host ("  FAIL（exit=$LASTEXITCODE）——CI 步骤 [$Name] 将失败") -ForegroundColor Red
+        $script:failures += $Name
+    } else {
+        Write-Host "  PASS" -ForegroundColor Green
+    }
+}
+
+if (-not (Test-PnpmAvailable)) {
+    Write-Host "错误：pnpm 与 corepack 均不可用——无法执行前端检查" -ForegroundColor Red
+    exit 1
+}
+
+# ---- 镜像 CI verify 的步骤（顺序与命令保持一致） ----
+
+Invoke-Step "Install frontend dependencies" {
+    Invoke-Pnpm @("install", "--frozen-lockfile")
+}
+
+Invoke-Step "Test frontend" {
+    Invoke-Pnpm @("test")
+}
+
+Invoke-Step "Build frontend" {
+    Invoke-Pnpm @("build")
+}
+
+Invoke-Step "Check Rust formatting" {
+    cargo fmt --all -- --check
+}
+
+Invoke-Step "Test Rust workspace" {
+    cargo test --workspace
+}
+
+Invoke-Step "Check Windows Tauri host" {
+    cargo check --workspace
+}
+
+if ($Full) {
+    Invoke-Step "Build Windows runtime simulation" {
+        $env:VITE_SAYALL_RUNTIME_SIMULATION = "1"
+        Invoke-Pnpm @("tauri", "build", "--no-bundle", "--features", "runtime-simulation")
+    }
+}
+
+# ---- 汇总 ----
+Write-Host ""
+if ($failures.Count -eq 0) {
+    Write-Host ("CI 前置自检全部通过（" + $script:step + " 步）——push 后 CI 的对应步骤应通过。" ) -ForegroundColor Green
+    exit 0
+} else {
+    Write-Host ("CI 前置自检失败 " + $failures.Count + " 项：") -ForegroundColor Red
+    foreach ($f in $failures) { Write-Host ("  - " + $f) -ForegroundColor Red }
+    Write-Host "修复后再 push（格式问题先 cargo fmt 并独立 style 提交）。"
+    exit 1
+}


### PR DESCRIPTION
## 内容

1. **windows-ci.yml paths-ignore**：**.md、docs/、Testing/、artifacts/、.gitignore、LICENSE 的改动不再触发 CI（此前纯文档 PR 也跑 19 分钟全量流水线）。
2. **scripts/ci-preflight.ps1**：本地镜像 CI verify 前 6 个快速步骤（前端依赖/测试/构建 + cargo fmt/test/check），push 前跑通 = CI 这些步骤必过；-Full 追加 runtime-simulation 构建。实测 6/6 通过。
3. **BRANCH_MANAGEMENT.md**：提交纪律新增 push 前跑 preflight。

## 验证

- preflight 在干净 worktree（基于 origin/main）实测 6/6 PASS（前端 18 测试、Rust 93 测试、fmt 干净）
- 本 PR 含 .ps1/.yml 改动 → 触发 CI → 顺带验证 workflow 语法与 paths-ignore 配置

注：脚本 UTF-8 BOM（PS 5.1 无 BOM 中文解析坑）。