### PR TITLE
发布准备:v0.2.0 版本号

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3102,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "sayall-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "sayall-windows"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "futures",
  "sayall-core",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "sayall-windows-app"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "sayall-core",
  "sayall-windows",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "GPL-3.0-only"
 repository = "https://github.com/GetSayAll/remote-mic-app-windows"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sayall-windows",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.15.0",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "无线麦 SayAll",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "identifier": "app.getsayall.remote-mic.windows",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
# 发布准备:v0.2.0 版本号

## 变更
- 根 `Cargo.toml` `workspace.package.version`、`src-tauri/tauri.conf.json`、`package.json` 同步 **0.1.0 → 0.2.0**;`Cargo.lock` 工作区成员版本由 `cargo check --workspace` 重新生成(3 处)。
- 仅版本号,无代码变更。

## 为什么是 0.2.0
- 应用内更新 E2E 即以 **0.1.0 → 0.2.0** 升级链路验证(Testing/2026-09-05-windows-updater-e2e.md)。
- `generate-updater-manifest.ps1` 强校验 tag 与 `tauri.conf.json` 版本一致——本 PR 合入后 main 即为 v0.2.0 tag 的发布基线。

## 验证
- 本地 `cargo check --workspace` 通过(仅 3 个工作区 crate 因版本变化重编,无新增警告)。
- 全量 CI(前端测试/构建、fmt、Rust 测试、运行时仿真、安装矩阵)随本 PR 运行。
