### PR TITLE
轮换更新签名公钥——首版正式密钥的空密码被 cmd 传参损坏

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -59,7 +59,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEM4NDkyQTNFOUNFRTVFRApSV1R0NWM3cG81S0VESEhqSjRNSkdOR05LakxzNnp1R0duVjk4UGw2TTNwMmhlZjUxc0FtUnhHZAo=",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDcyRUY0RDUwOEQ1ODAyNDgKUldSSUFsaU5VRTN2Y3ZleWlGT3AzSHpNZk5ka09TZFZRUHRsci9BVXJacmU0QTljSElnd0RydTQK",
       "endpoints": [
         "https://github.com/GetSayAll/remote-mic-app-windows/releases/latest/download/latest.json"
       ],


### PR DESCRIPTION
# 轮换更新签名公钥——首版正式密钥的空密码被 cmd 传参损坏

## 根因(全部实证)
- PR #24 合入的公钥(C8492A3E9CEE5ED)对应的私钥,生成时经 cmd 传递 `--password ""`,空字符串被 pnpm.CMD 链路损坏为**字面量两个引号字符**(`pnpm` 回显可见 `"--password" "\"\""`)。
- 实证:该私钥以字面量 `""` 为密码可解密签名;空字符串报 `incorrect updater private key password`。
- 后果:Release 工作流按设计以空密码变量签名(无密码密钥形态,本机 T4 实证可行),对这把密码损坏的密钥必然失败——[run 34013076021](https://github.com/GetSayAll/remote-mic-app-windows/actions/runs/34013076021) 实际失败于 Build signed NSIS installer。

## 处置
- 轮换为**真正无密码**正式密钥对,新公钥 `72EF4D508D580248`(经 PowerShell `--password=""` 合并 token 生成——与 CI 兜底脚本同款已实证路径)。
- 实证:新私钥空密码签名 ✅、字面量引号 ❌。
- GitHub Secret `TAURI_SIGNING_PRIVATE_KEY` 已同步为新私钥内容(本 PR 无关运行时,仅发布链路使用)。

## 影响面:零
旧公钥从未随任何已发布构建分发(v0.2.0 draft 未发布,无存量用户)。变更仅 tauri.conf.json 一行公钥。

## 验证
CI 全量随本 PR;合入后将删除并重建 v0.2.0 tag(未发布、无引用)重新触发 Release 工作流。
