### PR TITLE
fix: 更新检查文案终裁与版本号同源（404 呈现为已是最新版本）

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,7 +24,8 @@ use updater::{check_app_update, install_app_update};
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct RuntimeSnapshot {
-    app_version: &'static str,
+    /// 应用版本（package_info 同源；String 而非 &'static str——不再依赖编译期常量）。
+    app_version: String,
     platform: PlatformSnapshot,
 }
 
@@ -60,18 +61,32 @@ impl std::fmt::Debug for AppState {
 }
 
 #[tauri::command]
-fn get_runtime_snapshot(state: tauri::State<'_, AppState>) -> RuntimeSnapshot {
+fn get_runtime_snapshot(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+) -> RuntimeSnapshot {
     RuntimeSnapshot {
-        app_version: env!("CARGO_PKG_VERSION"),
+        // 版本统一取 package_info（tauri.conf.json 的 version，与安装包/更新器
+        // 比较同源）。此前用编译期 CARGO_PKG_VERSION（Cargo.toml），两者在
+        // "--config 覆盖版本"的本地构建/预发布场景会漂移（2026-09-06 实证：
+        // 安装 0.2.0 构建而关于页显示 0.1.0）。
+        app_version: app.package_info().version.to_string(),
         platform: state.platform.snapshot(),
     }
 }
 
 #[tauri::command]
-fn get_diagnostic_report(state: tauri::State<'_, AppState>) -> DiagnosticReport {
+fn get_diagnostic_report(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+) -> DiagnosticReport {
     let platform = state.platform.snapshot();
     let send_input = state.platform.send_input_snapshot();
-    DiagnosticReport::capture(env!("CARGO_PKG_VERSION"), &platform, &send_input)
+    DiagnosticReport::capture(
+        &app.package_info().version.to_string(),
+        &platform,
+        &send_input,
+    )
 }
 
 #[tauri::command]

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -17,7 +17,7 @@ use serde::Serialize;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter, State};
-use tauri_plugin_updater::UpdaterExt;
+use tauri_plugin_updater::{Error as UpdaterError, UpdaterExt};
 
 const CHECK_TIMEOUT: Duration = Duration::from_secs(30);
 const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(20 * 60);
@@ -25,6 +25,37 @@ const PROGRESS_EMIT_MIN_INTERVAL_BYTES: u64 = 128 * 1024;
 const ENDPOINT_OVERRIDE_ENV: &str = "SAYALL_UPDATER_ENDPOINT";
 /// 前端进度事件名（downloaded/contentLength/finished）。
 const PROGRESS_EVENT: &str = "app-update-progress";
+
+/// 端点无有效更新清单（如仓库尚无已发布 Release 导致 latest.json 404）时的
+/// 呈现规则（2026-09-06 用户终裁）：与"服务器确认无新版本"一致，均提示
+/// "已经是最新版本"，不让用户看到失败感文案；真实原因只写诊断日志。
+/// 已知代价：正式 Release 若漏挂 latest.json 资产，用户也会看到"已经是
+/// 最新版本"——由发布流程（windows-release.yml：缺 latest.json/.sig 即
+/// fail-fast 拒绝建 Release）与诊断日志（check.fail error=...）兜底。
+fn release_not_found_counts_as_up_to_date(error: &UpdaterError) -> bool {
+    matches!(error, UpdaterError::ReleaseNotFound)
+}
+
+/// 用户可见的检查失败文案（普通用户不看技术细节；原始错误只进诊断日志）。
+fn check_error_detail(error: &UpdaterError) -> String {
+    match error {
+        // 连接失败/超时/代理不可用。
+        UpdaterError::Reqwest(_) => "网络连接失败，请稍后重试".to_owned(),
+        _ => "检查暂时不可用，请稍后重试".to_owned(),
+    }
+}
+
+/// 用户可见的下载/安装失败文案（同上，去技术化）。
+fn install_error_message(error: &UpdaterError) -> String {
+    match error {
+        // 签名校验失败：安全相关，明确说"已停止安装"但不含术语。
+        UpdaterError::Minisign(_) => "更新包校验失败，已停止安装".to_owned(),
+        UpdaterError::Network(_) | UpdaterError::Reqwest(_) => {
+            "下载更新失败，请检查网络后重试".to_owned()
+        }
+        _ => "下载或安装暂时失败，请稍后重试".to_owned(),
+    }
+}
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -101,18 +132,18 @@ fn build_updater(
             note(format!(
                 "check.fail stage=endpoint_override_parse error={error:?}"
             ));
-            format!("更新端点覆盖变量 {ENDPOINT_OVERRIDE_ENV} 不是合法 URL：{error}")
+            "更新配置异常，请联系开发者".to_owned()
         })?;
         builder = builder.endpoints(vec![url]).map_err(|error| {
             note(format!(
                 "check.fail stage=endpoint_override_reject error={error:?}"
             ));
-            format!("更新端点覆盖被拒绝：{error}")
+            "更新配置异常，请联系开发者".to_owned()
         })?;
     }
     builder.build().map_err(|error| {
         note(format!("check.fail stage=build error={error:?}"));
-        format!("更新器初始化失败：{error}")
+        "更新功能暂时不可用，请稍后重试".to_owned()
     })
 }
 
@@ -143,7 +174,7 @@ pub async fn check_app_update(
             *state
                 .pending_update
                 .lock()
-                .map_err(|error| format!("更新状态锁损坏：{error}"))? = Some(update);
+                .map_err(|_error| "更新状态异常，请重启应用后重试".to_owned())? = Some(update);
             Ok(info)
         }
         Ok(None) => {
@@ -163,11 +194,26 @@ pub async fn check_app_update(
             })
         }
         Err(error) => {
+            // 日志保留插件原始错误（诊断用）；用户可见文案去技术化。
             note(format!(
                 "check.fail error={error:?} took_ms={}",
                 elapsed_ms(started)
             ));
-            Err(format!("检查更新失败：{error}"))
+            // 取不到清单（404 类）→ 呈现为"已经是最新版本"（2026-09-06 终裁）。
+            if release_not_found_counts_as_up_to_date(&error) {
+                note("check.presented_as_up_to_date reason=release_not_found".to_owned());
+                if let Ok(mut pending) = state.pending_update.lock() {
+                    *pending = None;
+                }
+                return Ok(AppUpdateInfo {
+                    current_version: app.package_info().version.to_string(),
+                    available: false,
+                    version: None,
+                    notes: None,
+                    date: None,
+                });
+            }
+            Err(check_error_detail(&error))
         }
     }
 }
@@ -180,12 +226,12 @@ pub async fn install_app_update(app: AppHandle, state: State<'_, AppState>) -> R
         .lock()
         .map_err(|error| {
             note(format!("install.fail stage=state_lock error={error:?}"));
-            format!("更新状态锁损坏：{error}")
+            "更新状态异常，请重启应用后重试".to_owned()
         })?
         .take()
         .ok_or_else(|| {
             note("install.fail stage=no_pending_update".to_owned());
-            "尚未发现可用更新，请先检查更新".to_owned()
+            "请先检查更新，再下载安装".to_owned()
         })?;
     note(format!("install.start version={}", update.version));
     // 下载整体超时（check 的超时不作用于下载请求）。
@@ -248,11 +294,12 @@ pub async fn install_app_update(app: AppHandle, state: State<'_, AppState>) -> R
                 .lock()
                 .map(|progress| progress.downloaded)
                 .unwrap_or(0);
+            // 日志保留插件原始错误（诊断用）；用户可见文案去技术化。
             note(format!(
                 "install.fail downloaded={downloaded} error={error:?} took_ms={}",
                 elapsed_ms(started)
             ));
-            Err(format!("下载或安装更新失败：{error}"))
+            Err(install_error_message(&error))
         }
     }
 }
@@ -260,6 +307,45 @@ pub async fn install_app_update(app: AppHandle, state: State<'_, AppState>) -> R
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// 取不到清单（ReleaseNotFound，404 类）按"已经是最新版本"呈现；
+    /// 其他错误（网络/IO 等）不享受该待遇，仍如实报错（2026-09-06 终裁）。
+    #[test]
+    fn release_not_found_is_presented_as_up_to_date() {
+        assert!(release_not_found_counts_as_up_to_date(
+            &UpdaterError::ReleaseNotFound
+        ));
+        assert!(!release_not_found_counts_as_up_to_date(
+            &UpdaterError::Network("x".to_owned())
+        ));
+        assert!(!release_not_found_counts_as_up_to_date(
+            &UpdaterError::EmptyEndpoints
+        ));
+    }
+
+    /// 用户可见文案不得包含技术文本（原始错误只进诊断日志）。
+    #[test]
+    fn user_facing_error_copy_is_plain_chinese() {
+        let network = UpdaterError::Network("download failed at byte 4096".to_owned());
+        assert_eq!(
+            install_error_message(&network),
+            "下载更新失败，请检查网络后重试"
+        );
+        let io_check = UpdaterError::Io(std::io::Error::other("os error 123"));
+        assert_eq!(check_error_detail(&io_check), "检查暂时不可用，请稍后重试");
+        let io_install = UpdaterError::Io(std::io::Error::other("os error 123"));
+        assert_eq!(
+            install_error_message(&io_install),
+            "下载或安装暂时失败，请稍后重试"
+        );
+        // 签名类错误的安全文案（minisign 错误不可直接构造，用 Network 分支旁证
+        // 映射完整性由编译保证）。
+        let fallback = UpdaterError::EmptyEndpoints;
+        assert_eq!(
+            install_error_message(&fallback),
+            "下载或安装暂时失败，请稍后重试"
+        );
+    }
 
     /// Rust ↔ TypeScript JSON 契约（对齐仓库既有 PlatformSnapshot 契约夹具做法）。
     #[test]

--- a/src/pages/AboutPage.test.ts
+++ b/src/pages/AboutPage.test.ts
@@ -149,13 +149,31 @@ describe("about page update panel", () => {
 
   it("失败时展示错误并提供重试检查", async () => {
     phase.value = "failed";
-    errorMessage.value = "检查更新失败：网络错误";
+    errorMessage.value = "网络连接失败，请稍后重试";
     const wrapper = mount(AboutPage, { props: { runtime } });
     await flushPromises();
-    expect(wrapper.text()).toContain("检查更新失败：网络错误");
+    expect(wrapper.text()).toContain("网络连接失败，请稍后重试");
     const retry = wrapper.findAll("button").find((b) => b.text().includes("重试检查"));
     expect(retry).toBeDefined();
     await retry!.trigger("click");
     expect(check).toHaveBeenCalledTimes(1);
+  });
+
+  it("服务器确认无更新时显示已经是最新版本", async () => {
+    phase.value = "up-to-date";
+    info.value = {
+      currentVersion: "0.2.0",
+      available: false,
+      version: null,
+      notes: null,
+      date: null,
+    };
+    const wrapper = mount(AboutPage, { props: { runtime } });
+    await flushPromises();
+    expect(wrapper.text()).toContain("已经是最新版本。");
+    const installButton = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("下载并安装"));
+    expect(installButton).toBeUndefined();
   });
 });

--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -57,7 +57,7 @@ async function onInstall(): Promise<void> {
           正在下载更新… {{ appUpdateProgressText(progress) }}
         </p>
         <p v-else-if="checking" class="muted">正在检查更新…</p>
-        <p v-else-if="upToDate" class="muted">已是最新版本。</p>
+        <p v-else-if="upToDate" class="muted">已经是最新版本。</p>
         <p v-else-if="failed" class="update-error">{{ errorMessage }}</p>
         <p v-else class="muted">手动检查是否有新版本。</p>
 


### PR DESCRIPTION
## 内容

- 取不到更新清单（ReleaseNotFound，如 latest.json 404 / 代理非 2xx）按“已经是最新版本”呈现（2026-09-06 用户终裁）；真实原因仍写 SAYALL_GATT_LOG，发布流程缺 latest.json/.sig 即 fail-fast 兜底
- 全部用户可见错误文案去技术化（网络/校验/初始化分类中文文案；原始英文错误只进诊断日志），单测锁定
- 关于页与诊断摘要版本号改取 app.package_info()（与安装包、更新器同源），修复版本显示漂移

## 验证

- cargo test --workspace 102 项 / 前端 35 项 / cargo fmt / vue-tsc+vite build 全绿
- 本机端到端：404 端点 + CDP 驱动真实 UI 出现“已经是最新版本”；GitHub 实际断连时显示“网络连接失败，请稍后重试”

基于 origin/main（2c40ec7）创建，仅含本工作项 4 个文件（136+/17-），不含并行进行中的按键映射/自定义应用改动。