### PR TITLE
fix: 请求 BLE 高吞吐连接参数以稳定语音帧送达

### DIFF
--- a/Bugs/2026-09-07-ble-unreachable-both-remotes.md
+++ b/Bugs/2026-09-07-ble-unreachable-both-remotes.md
@@ -1,0 +1,73 @@
+# 双遥控器 BLE Unreachable（GATT 状态 1）：多手段自愈矩阵实测 + 语音链路零日志缺陷
+
+## 现象（2026-09-07 用户报障）
+
+- 上午起两只遥控器（RC001 + RC003）均连不上；应用 UI 显示
+  "正在等待遥控器重连"，错误文案
+  `Xiaomi voice remote GATT operation failed: 发现 ATVV 服务返回状态 1；将在 N 秒后进行第 N 次重连`。
+- Windows `GattCommunicationStatus` 状态 1 = **Unreachable（设备不可达）**：
+  不是 GATT 表损坏，是蓝牙链路根本建立不起来。
+- 前情：同日上午用户报"RC001 连上但语音没声音"（未及单独定位，连接即恶化）。
+- 经典蓝牙 HID 层正常：PnP 两只遥控器 Status=OK；用户按键后应用的
+  wake_reconnect 退避重置机制可观测（UI 重试计数回退）。
+
+## 系统侧排查（全部实际执行）
+
+| 检查项 | 结果 |
+| --- | --- |
+| bthserv 蓝牙服务 | RUNNING，正常 |
+| Intel 蓝牙适配器（PnP） | OK |
+| 两只遥控器 PnP 节点 | 都 OK（配对完好） |
+| Windows 事件日志（蓝牙通道 + System，3 小时） | 无蓝牙相关错误 |
+| 应用进程 | 运行中，自动重连循环正常（2–30s 指数退避持续爬升到第 33+ 次） |
+
+## 恢复尝试矩阵（时序 + 结果）
+
+1. **PnP 级无线电复位**（Disable→Enable Intel 蓝牙 USB 节点，
+   USB\VID_8087&PID_0A2B）：**当场无效**（failed）——遥控器深度睡眠
+   不广播时主机侧无从连接；对 BT 外设秒级瞬断。
+2. **优雅退出 + 带日志重启**（WM_CLOSE→应用托盘驻留未退出；改用
+   Toolhelp32 枚举线程 + PostThreadMessage WM_QUIT 正常退出路径成功，
+   Rust drop/BLE 清理正常执行）：重启后仍 Unreachable（failed）。
+3. **bthserv 重启**：非提权会话权限不足（无法执行，deferred）。
+4. **用户多次按两只遥控器按键**（配合第 2 步重启后的持续重连循环）：
+   **约 20 分钟内连接恢复**（passed）——恢复后语音会话连续成功
+   （日志 session 32–36：chord_press ok、wetype_check reacted=true、
+   MIC_EXTEND 续期 `T 0E` 正常）、按键映射正常（Menu→打开微信 ok）、
+   UI 显示"已连接"。
+
+## 结论
+
+- 故障特征：**双遥控器同时 BLE Unreachable + HID 层正常 + 无线电复位
+  当场无效 + 按键唤醒后自愈成功**。与 09-05 复盘的"强杀残留链路僵死"
+  不同：本次无强杀，且自愈周期远超 60 秒（依赖用户按键唤醒遥控器）。
+- 最可能机理：遥控器深度睡眠后 BLE 不广播；无线电复位清不掉"遥控器
+  侧不广播"这一状态；多次按键唤醒 + 持续重连循环最终建立链路。为何
+  首次唤醒按键未立即恢复（wake_reconnect 触发的立即重连仍 Unreachable）
+  待后续复现取证——当前 BLE 链路零日志（见缺陷），无法回放每次尝试。
+- 另：bthserv 层是否需要复位未验证（权限限制），留作下次复现时的
+  对照项。
+
+## 暴露的缺陷（待修复）
+
+1. **BLE 连接/重连链路零日志**（违反"功能点必须自带日志"规范）：
+   attempt_connection、find_service 失败、重连调度均无 gatt_note 打点。
+   本次定位只能依赖 UI last_error 与恢复后的间接证据；"radio_recovery
+   自愈是否运行过"也无法从日志确认。修复：连接路径全分支打点
+   （attempt 开始/结果/退避/唤醒/无线电恢复），一次报障 + 一次日志
+   拉取即定位。
+2. **Raw Input 监听失败提示不区分原因**：UI 显示"监听启动失败（自动
+   重试中）"，实际是遥控器不可达时 HID 设备节点缺失的果——应区分
+   "等待设备"与"真异常"并落日志。
+
+## 验证
+
+- 事件日志、PnP、服务状态检查：passed（见上表）。
+- PnP 无线电复位后 72 秒监测：failed（仍 Unreachable）。
+- WM_QUIT 优雅退出 + 带日志重启：passed（进程正常退出、新实例日志
+  正常落盘）。
+- 按键唤醒 + 重连循环：passed（连接恢复，语音/映射功能正常）。
+- 诊断脚本归档：Testing/investigation/conn-status.ps1、graceful-stop-app.ps1、
+  radio-cycle.ps1、tray-quit.ps1、find-tray-icon.ps1、tray-quit2.ps1、
+  wmquit-app.ps1、start-with-diag.ps1、long-poll.ps1、dump-diag.ps1、
+  restart-bthserv*.ps1、show-and-read-ui.ps1、switch-to-conn-page.ps1。

--- a/Testing/investigation/analyze-sessions.ps1
+++ b/Testing/investigation/analyze-sessions.ps1
@@ -1,0 +1,58 @@
+# Analyze voice sessions: v2 with regex (avoid -like bracket wildcard trap)
+# ASCII only.
+$ErrorActionPreference = 'SilentlyContinue'
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$log = "$env:USERPROFILE\sayall-diag.log"
+
+$reStart = '^C (\d+) len=\s*4 b=\[04 03 02'
+$reStop  = '^C (\d+) len=\s*2 b=\[00 02\]'
+$reA     = '^A (\d+) len=120'
+
+$inSession = $false
+$sessionStart = 0L
+$frames = 0
+$lastFrameTs = 0L
+$sessionNo = 0
+$gapsOver100 = 0
+$maxGap = 0
+$gapsOver250 = 0
+$report = @()
+$openStart = 0L
+$openFrames = 0
+
+foreach ($line in (Get-Content $log)) {
+    if ($line -match $reStart) {
+        if ($inSession) { $report += "session#$sessionNo UNTERMINATED frames=$frames" }
+        $sessionNo++
+        $inSession = $true
+        $frames = 0; $gapsOver100 = 0; $gapsOver250 = 0; $maxGap = 0
+        $sessionStart = [long]$matches[1]
+        $lastFrameTs = $sessionStart
+    }
+    elseif ($line -match $reA) {
+        if ($inSession) {
+            $frames++
+            $ts = [long]$matches[1]
+            if ($ts -gt $lastFrameTs) {
+                $gap = $ts - $lastFrameTs
+                if ($gap -gt 100) { $gapsOver100++ }
+                if ($gap -gt 250) { $gapsOver250++ }
+                if ($gap -gt $maxGap) { $maxGap = $gap }
+            }
+            $lastFrameTs = $ts
+        }
+    }
+    elseif ($line -match $reStop) {
+        if ($inSession) {
+            $span = $lastFrameTs - $sessionStart
+            $audioSec = [math]::Round($frames * 0.015, 2)
+            $spanSec = [math]::Round($span / 1000.0, 2)
+            $ratio = if ($spanSec -gt 0) { [math]::Round($audioSec / $spanSec * 100, 1) } else { 0 }
+            $report += "session#$sessionNo span=${spanSec}s frames=$frames audio=${audioSec}s realtime=${ratio}% gaps>100ms=$gapsOver100 gaps>250ms=$gapsOver250 maxGap=${maxGap}ms"
+            $inSession = $false
+        }
+    }
+}
+if ($inSession) { $report += "session#$sessionNo STILL_OPEN frames=$frames" }
+Write-Output "TOTAL_SESSIONS=$sessionNo"
+$report

--- a/Testing/investigation/conn-status.ps1
+++ b/Testing/investigation/conn-status.ps1
@@ -1,0 +1,31 @@
+# 状态采集：应用进程 / 应用安装位置 / 蓝牙无线电（无线麦连接报障排查）
+$ErrorActionPreference = 'SilentlyContinue'
+
+Write-Output '=== PROCESS ==='
+Get-Process | Where-Object { $_.ProcessName -like '*sayall*' -or $_.ProcessName -like '*remote-mic*' } |
+    Select-Object ProcessName, Id, StartTime | Format-Table -AutoSize
+
+Write-Output '=== APP DIRS ==='
+foreach ($dir in Get-ChildItem $env:LOCALAPPDATA -Directory) {
+    if ($dir.Name -like '*SayAll*' -or $dir.Name -like 'app.getsayall*') {
+        Write-Output "DIR: $($dir.FullName)"
+        Get-ChildItem $dir.FullName -Recurse -Filter *.exe |
+            Select-Object -First 5 | ForEach-Object { Write-Output "EXE: $($_.FullName) $($_.LastWriteTime)" }
+    }
+}
+
+Write-Output '=== BLUETOOTH RADIO ==='
+Get-PnpDevice -Class Bluetooth |
+    Select-Object Status, FriendlyName | Format-Table -AutoSize | Out-String -Width 120
+
+Write-Output '=== BLUETOOTH LE DEVICES ==='
+Get-PnpDevice | Where-Object { $_.InstanceId -like '*DEV_*' -and $_.Class -eq 'Bluetooth' } |
+    Select-Object -First 10 Status, FriendlyName | Format-Table -AutoSize | Out-String -Width 120
+
+Write-Output '=== DIAG LOG ==='
+if (Test-Path "$env:USERPROFILE\sayall-diag.log") {
+    Write-Output "FOUND $($env:USERPROFILE)\sayall-diag.log"
+    Get-Item "$env:USERPROFILE\sayall-diag.log" | Select-Object Length, LastWriteTime | Format-List
+} else {
+    Write-Output 'NO DIAG LOG'
+}

--- a/Testing/investigation/radio-cycle.ps1
+++ b/Testing/investigation/radio-cycle.ps1
@@ -1,0 +1,53 @@
+# Step 2b: bluetooth radio off/on - attempt WinRT then fallback to PnP device restart
+# ASCII only.
+$ErrorActionPreference = 'SilentlyContinue'
+[void][Windows.Devices.Radio.Radio,Windows.System.Devices,ContentType=WindowsRuntime]
+
+$winrtLoaded = $null -ne ([System.Management.Automation.PSTypeName]'Windows.Devices.Radio.Radio').Type
+Write-Output "WINRT_TYPE_LOADED=$winrtLoaded"
+
+if ($winrtLoaded) {
+    [void][WindowsRuntimeSystemExtensions]
+    Add-Type -AssemblyName System.Runtime.WindowsRuntime
+    $asTaskGeneric = ([System.WindowsRuntimeSystemExtensions].GetMethods() | Where-Object {
+        $_.Name -eq 'AsTask' -and $_.GetParameters().Count -eq 1 -and $_.GetParameters()[0].ParameterType.Name -eq 'IAsyncOperation`1'
+    })[0]
+    function Await($WinRtTask, $ResultType) {
+        $asTask = $asTaskGeneric.MakeGenericMethod($ResultType)
+        $netTask = $asTask.Invoke($null, @($WinRtTask))
+        $netTask.Wait(-1) | Out-Null
+        $netTask.Result
+    }
+    $radios = Await ([Windows.Devices.Radio.Radio]::GetRadiosAsync()) ([System.Collections.Generic.IReadOnlyList[Windows.Devices.Radio.Radio]])
+    $bt = $radios | Where-Object { $_.Kind -eq 'Bluetooth' } | Select-Object -First 1
+    if ($bt) {
+        Write-Output "RADIO=$($bt.Name) STATE=$($bt.State)"
+        Write-Output 'RADIO_OFF...'
+        $null = Await ($bt.SetStateAsync('Disabled')) ([Windows.Devices.Radio.RadioState])
+        Start-Sleep -Seconds 4
+        Write-Output 'RADIO_ON...'
+        $null = Await ($bt.SetStateAsync('Enabled')) ([Windows.Devices.Radio.RadioState])
+        Start-Sleep -Seconds 4
+        $radios = Await ([Windows.Devices.Radio.Radio]::GetRadiosAsync()) ([System.Collections.Generic.IReadOnlyList[Windows.Devices.Radio.Radio]])
+        $bt = $radios | Where-Object { $_.Kind -eq 'Bluetooth' } | Select-Object -First 1
+        Write-Output "RADIO_STATE_AFTER_ON=$($bt.State)"
+        Write-Output 'WINRT_DONE'
+        exit 0
+    }
+    Write-Output 'NO_BT_RADIO_FALLBACK_PNP'
+}
+
+# Fallback: restart the BT radio PnP device node (public device management API)
+$btDev = Get-PnpDevice -Class Bluetooth | Where-Object { $_.FriendlyName -like '*Bluetooth*' -and $_.Status -eq 'OK' -and $_.InstanceId -like 'USB\*' } | Select-Object -First 1
+if (-not $btDev) {
+    $btDev = Get-PnpDevice -Class Bluetooth | Where-Object { $_.FriendlyName -like '*Intel*Bluetooth*' } | Select-Object -First 1
+}
+if (-not $btDev) { Write-Output 'NO_PNP_BT_DEVICE'; exit 2 }
+Write-Output "PNP_RESTART=$($btDev.FriendlyName) ID=$($btDev.InstanceId)"
+Disable-PnpDevice -InstanceId $btDev.InstanceId -Confirm:$false
+Start-Sleep -Seconds 5
+Enable-PnpDevice -InstanceId $btDev.InstanceId -Confirm:$false
+Start-Sleep -Seconds 5
+$after = Get-PnpDevice -InstanceId $btDev.InstanceId
+Write-Output "PNP_AFTER=$($after.Status)"
+Write-Output 'PNP_DONE'

--- a/Testing/investigation/start-with-diag.ps1
+++ b/Testing/investigation/start-with-diag.ps1
@@ -1,0 +1,62 @@
+# Step 5: rotate old diag log, start app WITH SAYALL_GATT_LOG, wait, poll UI
+# ASCII only.
+$ErrorActionPreference = 'SilentlyContinue'
+Add-Type -AssemblyName UIAutomationClient
+Add-Type -AssemblyName UIAutomationTypes
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+# rotate old log (keep history; do not delete per repo rule)
+$old = "$env:USERPROFILE\sayall-diag.log"
+if (Test-Path $old) {
+    Move-Item $old "$env:USERPROFILE\sayall-diag-20260906.log" -Force
+    Write-Output 'OLD_LOG_ROTATED'
+}
+
+$exe = $null
+foreach ($d in Get-ChildItem $env:LOCALAPPDATA -Directory) {
+    if ($d.Name -like '*SayAll*') {
+        $cand = Get-ChildItem $d.FullName -Filter 'sayall-windows-app.exe' -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($cand) { $exe = $cand.FullName; break }
+    }
+}
+if (-not $exe) { Write-Output 'EXE_NOT_FOUND'; exit 1 }
+Write-Output "EXE=$exe"
+
+$env:SAYALL_GATT_LOG = "$env:USERPROFILE\sayall-diag.log"
+Start-Process -FilePath $exe
+Write-Output 'APP_STARTED_WITH_DIAG'
+
+# wait for process + first reconnect cycle
+Start-Sleep -Seconds 20
+$proc = Get-Process -Name 'sayall-windows-app'
+if (-not $proc) { Write-Output 'APP_NOT_RUNNING_AFTER_START'; exit 2 }
+Write-Output "RUNNING PID=$($proc.Id)"
+
+if (Test-Path "$env:USERPROFILE\sayall-diag.log") {
+    $sz = (Get-Item "$env:USERPROFILE\sayall-diag.log").Length
+    Write-Output "DIAG_LOG_SIZE=$sz"
+} else {
+    Write-Output 'DIAG_LOG_NOT_CREATED_YET'
+}
+
+# poll UI phase for up to 60s
+$waiting = [char]0x6B63 + [char]0x5728 + [char]0x7B49 + [char]0x5F85
+$connected = [char]0x5DF2 + [char]0x8FDE + [char]0x63A5
+$ready = [char]0x5C31 + [char]0x7EEA
+for ($i = 1; $i -le 10; $i++) {
+    Start-Sleep -Seconds 6
+    $p2 = Get-Process -Name 'sayall-windows-app'
+    if (-not $p2) { Write-Output "T+$($i*6)s APP_GONE"; break }
+    $root = [System.Windows.Automation.AutomationElement]::FromHandle($p2.MainWindowHandle)
+    if (-not $root) { continue }
+    $texts = $root.FindAll([System.Windows.Automation.TreeScope]::Descendants, [System.Windows.Automation.Condition]::TrueCondition)
+    $phase = ''; $err = ''
+    foreach ($t in $texts) {
+        $n = $t.Current.Name
+        if (-not $n) { continue }
+        if ($n -like "$waiting*" -or $n -eq $connected -or $n -eq $ready) { $phase = $n }
+        if ($n -like '*GATT*' -or $n -like '*failed*' -or $n -like '*Unreachable*') { $err = $n }
+    }
+    Write-Output "T+$($i*6)s PHASE=[$phase] ERR=[$err]"
+    if ($phase -eq $connected -or $phase -eq $ready) { Write-Output 'CONNECTED_OK'; break }
+}

--- a/Testing/investigation/wmquit-app.ps1
+++ b/Testing/investigation/wmquit-app.ps1
@@ -1,0 +1,48 @@
+# Step 4e: WM_QUIT via Toolhelp32 thread snapshot. ASCII only.
+$ErrorActionPreference = 'SilentlyContinue'
+
+$proc = Get-Process -Name 'sayall-windows-app'
+if (-not $proc) { Write-Output 'NOT_RUNNING'; exit 0 }
+Write-Output "PID=$($proc.Id)"
+
+Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+public class ThreadQuit {
+    [DllImport("user32.dll")] public static extern bool PostThreadMessage(uint tid, uint msg, IntPtr w, IntPtr l);
+    [StructLayout(LayoutKind.Sequential)]
+    public struct THREADENTRY32 { public uint dwSize, cntUsage, th32ThreadID, th32OwnerProcessID;
+        public int tpBasePri, tpDeltaPri, dwFlags; }
+    [DllImport("kernel32.dll")] public static extern IntPtr CreateToolhelp32Snapshot(uint flags, uint pid2);
+    [DllImport("kernel32.dll")] public static extern bool Thread32First(IntPtr h, ref THREADENTRY32 e);
+    [DllImport("kernel32.dll")] public static extern bool Thread32Next(IntPtr h, ref THREADENTRY32 e);
+    [DllImport("kernel32.dll")] public static extern bool CloseHandle(IntPtr h);
+
+    public static uint[] ThreadsOf(uint pid2) {
+        IntPtr h = CreateToolhelp32Snapshot(0x00000004, pid2);
+        if (h == (IntPtr)(-1)) return new uint[0];
+        var list = new System.Collections.Generic.List<uint>();
+        THREADENTRY32 e = new THREADENTRY32();
+        e.dwSize = (uint)Marshal.SizeOf(typeof(THREADENTRY32));
+        if (Thread32First(h, ref e)) {
+            do { if (e.th32OwnerProcessID == pid2) list.Add(e.th32ThreadID); }
+            while (Thread32Next(h, ref e));
+        }
+        CloseHandle(h);
+        return list.ToArray();
+    }
+}
+"@
+
+$tids = [ThreadQuit]::ThreadsOf([uint32]$proc.Id)
+Write-Output "THREADS=$($tids.Count) ids=$($tids -join ',')"
+if ($tids.Count -eq 0) { Write-Output 'NO_THREADS'; exit 2 }
+
+# try every thread with WM_QUIT (only threads with a message loop will act on it)
+foreach ($tid in $tids) {
+    $ok = [ThreadQuit]::PostThreadMessage($tid, 0x0012, [IntPtr]::Zero, [IntPtr]::Zero)
+    Write-Output "WM_QUIT tid=$tid result=$ok"
+}
+Start-Sleep -Seconds 5
+if (Get-Process -Name 'sayall-windows-app') { Write-Output 'STILL_RUNNING'; exit 3 }
+Write-Output 'APP_EXITED'

--- a/crates/sayall-windows/src/ble.rs
+++ b/crates/sayall-windows/src/ble.rs
@@ -21,6 +21,7 @@ use windows::Devices::Bluetooth::GenericAttributeProfile::{
 };
 use windows::Devices::Bluetooth::{
     BluetoothCacheMode, BluetoothConnectionStatus, BluetoothLEDevice,
+    BluetoothLEPreferredConnectionParameters, BluetoothLEPreferredConnectionParametersRequest,
 };
 use windows::Foundation::TypedEventHandler;
 use windows::Storage::Streams::{DataReader, DataWriter, IBuffer};
@@ -1263,6 +1264,9 @@ struct BleSession {
     audio_token: i64,
     control_token: i64,
     connection_token: i64,
+    /// ThroughputOptimized 连接参数请求（2026-09-07 新增）：持有以维持偏好
+    /// 生效；Windows 11 前的宿主上请求失败时为 None（降级默认参数）。
+    params_request: Option<BluetoothLEPreferredConnectionParametersRequest>,
     microphone_opened: bool,
     closed: bool,
     cleanup_failure: Option<String>,
@@ -1278,6 +1282,32 @@ impl BleSession {
         let device = block_on(
             BluetoothLEDevice::FromIdAsync(&HSTRING::from(device_id)).map_err(windows_error)?,
         )?;
+        // 连接参数吞吐优化（2026-09-07）：RC001 送达率实测仅 ~52%（18 会话
+        // 全部 39%-68%，同 09-04 RC003 初次配对的 55% 症状；09-04 RC001
+        // 基准为 100%）。ThroughputOptimized 收紧连接间隔，提升 15ms/120B
+        // 音频帧的实时送达；对两型号统一生效（RC003 只会更好）。
+        // Windows 11（22000+）起可用：旧宿主调用失败降级默认参数，不阻断
+        // 连接，结果落 gatt_note（"功能点必须自带日志"）。
+        let params_request = match BluetoothLEPreferredConnectionParameters::ThroughputOptimized() {
+            Ok(parameters) => match device.RequestPreferredConnectionParameters(&parameters) {
+                Ok(request) => {
+                    gatt_note("conn_params result=ok mode=throughput_optimized".to_owned());
+                    Some(request)
+                }
+                Err(error) => {
+                    gatt_note(format!(
+                        "conn_params result=unavailable err={error} mode=throughput_optimized"
+                    ));
+                    None
+                }
+            },
+            Err(error) => {
+                gatt_note(format!(
+                    "conn_params result=unavailable err={error} mode=throughput_optimized"
+                ));
+                None
+            }
+        };
         let name = device.Name().map_err(windows_error)?.to_string();
         let inferred_model = remote_model_from_name(&name);
         let model = if inferred_model == RemoteModel::Unknown {
@@ -1364,6 +1394,7 @@ impl BleSession {
             audio_token,
             control_token,
             connection_token,
+            params_request,
             microphone_opened: false,
             closed: false,
             cleanup_failure: None,
@@ -1453,6 +1484,10 @@ impl BleSession {
         // notification disable remains best-effort in that expected state.
         let _ = disable_notifications(&self.audio);
         let _ = disable_notifications(&self.control);
+        // 连接参数请求先于设备释放（request 活跃期与 device 绑定）。
+        if let Some(request) = self.params_request.take() {
+            let _ = request.Close();
+        }
         if let Err(error) = self.service.Close() {
             errors.push(format!("关闭 GATT service：{error}"));
         }


### PR DESCRIPTION
## 目的

解决 RC001/RC003 ATVV 语音链路因默认 BLE 连接间隔吞吐不足导致的音频帧低送达率问题。

连接建立后通过 Windows 公开 API 请求 ThroughputOptimized 连接参数，并在会话关闭时释放请求对象。API 不可用或请求失败时降级到系统默认参数，不阻断连接；结果写入结构化 GATT 诊断日志。

## 变更

- 在 BleSession 生命周期内持有 BluetoothLEPreferredConnectionParametersRequest
- 连接后请求 ThroughputOptimized
- 关闭会话时成对释放请求
- 记录 conn_params result=ok/unavailable 日志
- 归档双遥控器 BLE Unreachable 调查和送达率分析脚本

## 验证

- scripts/ci-preflight.ps1：6/6 passed
- 前端：44 tests passed
- Rust：114 tests passed（另 1 个需要真实 CABLE 端点的测试 ignored）
- cargo fmt --check：passed
- Windows Tauri host check：passed
- RC001：已有真机吞吐改善记录
- RC003：deferred，需单独真机验证该 API 生效、送达率及无回归

## 合入门禁

保持 Draft；RC003 真机验收完成前不宣称双型号 passed，不合入 main。