### PR TITLE
release: prepare Windows preview 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3102,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "sayall-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "sayall-windows"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "futures",
  "sayall-core",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "sayall-windows-app"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "sayall-core",
  "sayall-windows",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "GPL-3.0-only"
 repository = "https://github.com/GetSayAll/remote-mic-app-windows"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sayall-windows",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.15.0",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "无线麦 SayAll",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "app.getsayall.remote-mic.windows",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/pages/AboutPage.test.ts
+++ b/src/pages/AboutPage.test.ts
@@ -99,6 +99,8 @@ describe("about page update panel", () => {
     const wrapper = mount(AboutPage, { props: { runtime } });
     expect(wrapper.text()).toContain("软件更新");
     expect(wrapper.text()).toContain("手动检查是否有新版本");
+    expect(wrapper.text()).not.toContain("开源许可");
+    expect(wrapper.text()).not.toContain("GPL-3.0");
     const button = wrapper.findAll("button").find((b) => b.text().includes("检查更新"));
     expect(button).toBeDefined();
   });

--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -37,7 +37,6 @@ async function onInstall(): Promise<void> {
       <div>
         <h2>无线麦 SayAll</h2>
         <p>版本 {{ runtime?.appVersion ?? "0.1.0" }}</p>
-        <p class="muted">开源许可 GPL-3.0。</p>
       </div>
     </article>
 

--- a/src/pages/ConnectionPage.test.ts
+++ b/src/pages/ConnectionPage.test.ts
@@ -117,6 +117,7 @@ describe("VB-CABLE first-launch guidance", () => {
     expect(mocks.selectAudioEndpoint).toHaveBeenCalledWith(cableEndpoint.id);
     expect(wrapper.text()).toContain("已自动选择 CABLE Input");
     expect(wrapper.text()).not.toContain("需要安装 VB-CABLE");
+    expect(wrapper.text()).not.toContain("系统语音输入");
     wrapper.unmount();
   });
 

--- a/src/pages/ConnectionPage.vue
+++ b/src/pages/ConnectionPage.vue
@@ -73,7 +73,6 @@ let pollTimer: ReturnType<typeof setInterval> | undefined;
 const voiceHotkeyPresets: Array<{ label: string; keys: string[] }> = [
   { label: "微信输入法（默认）", keys: ["left_control", "left_windows"] },
   { label: "关闭", keys: [] },
-  { label: "系统语音输入", keys: ["left_windows", "h"] },
 ];
 
 const activeVoiceHotkeyKeys = computed(() =>


### PR DESCRIPTION
## 变更
- 从连接与语音页面移除“系统语音输入”选项
- 从关于页面移除开源协议信息
- 将应用版本统一更新为 0.2.1

## 验证
- CI 前置自检 6/6 passed
- 前端测试 44/44 passed
- Rust：25 core + 4 RC001 replay + 75 Windows + 1 IPC + 10 app passed（1 个需要显式音频端点的测试 ignored）
- Windows 普通用户路径 E2E passed：全新安装 → RC003（小米蓝牙遥控器 2 Pro）→ VB-CABLE → 成功语音转文字
- 更新检查逻辑测试 passed；当前正式 latest 更新端点因尚无已发布稳定版而返回 404

## 发布说明
合入后从最新 main 创建 v0.2.1，并发布为 GitHub prerelease。

## 已知发布风险
仓库历史敏感信息审计尚未闭环：存在个人作者邮箱、真实蓝牙地址及个人绝对路径；未发现真实 API Key/私钥。此 PR 不宣称敏感信息审计通过。