### PR TITLE
docs: 统一 README 小米遥控器型号命名

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 无线麦 SayAll for Windows
 
-无线麦 SayAll Windows 版已完成对小米蓝牙遥控器 2（RC001）和小米蓝牙遥控器 2 Pro（RC003）的 Windows 真机适配，覆盖设备识别、连接、按键映射和语音桥接等已验证场景。项目采用 Rust、Tauri 2 和 Vue 3，Windows 与 macOS 分别维护和发布。
+无线麦 SayAll Windows 版已完成对小米蓝牙遥控器 2（RC001）和 2 Pro（RC003）的 Windows 真机适配，覆盖设备识别、连接、按键映射和语音桥接等已验证场景。项目采用 Rust、Tauri 2 和 Vue 3，Windows 与 macOS 分别维护和发布。
 
 参考源码仓库：[HD838A/remote-mic-app](https://github.com/HD838A/remote-mic-app)（macOS 版）。Windows 版保持独立的平台实现，仅参考其公开的产品行为、协议经验和测试边界，不回填 macOS 代码。
 


### PR DESCRIPTION
将 README 项目介绍中的型号名称统一为：小米蓝牙遥控器 2（RC001）和 2 Pro（RC003）。GitHub About 已同步更新为同一 Windows 产品描述。仅文档变更，git diff --check passed。