### PR TITLE
feat: add persistent privacy-safe diagnostics

### DIFF
--- a/LOGGING.md
+++ b/LOGGING.md
@@ -35,6 +35,12 @@ windows_build=<build 或 unknown>
 
 构建时写入 `source_revision`，运行时不得读取 Git 工作区。无法可靠取得的值写 `unknown`，不能省略字段。
 
+正式应用默认写入 `%LOCALAPPDATA%\SayAll\Logs\sayall-diagnostic.log`，不再要求用户
+预先设置环境变量。受控测试仍可用 `SAYALL_GATT_LOG` 覆盖写入位置；日志正文不得
+打印实际文件路径。应用启动、Tauri setup、前端入口、Vue 挂载和首次 IPC 读取必须
+在用户看到主页面前后分别留痕，确保安装后白屏可以区分为宿主、WebView、脚本、
+Vue 渲染或 IPC 阶段故障。
+
 ## 必需事件链
 
 每项功能按实际存在的边界记录：
@@ -53,6 +59,10 @@ windows_build=<build 或 unknown>
 ## 隐私红线
 
 不得记录语音或转写正文、用户输入、剪贴板、用户名/邮箱/手机号、完整路径、窗口标题、蓝牙 MAC/UUID/序列号、HID 路径、IP、Token/API Key/密码/私钥/证书、第三方 App 私有状态或原始音频字节。不要用敏感值的稳定哈希替代脱敏。允许记录稳定产品分类、布尔结果、错误 domain/code、采样率、帧数、耗时和脱敏计数。
+
+生产日志不得记录原始音频包；GATT 音频只在会话终态聚合帧数、样本数、丢弃数
+和耗时。音频端点只记录 `virtual_cable|bluetooth|other` 分类及计数，不记录名称、
+端点 ID 或蓝牙身份。
 
 ## 评审清单
 

--- a/TODO.md
+++ b/TODO.md
@@ -30,6 +30,7 @@
 - [ ] 验证 `STREAM_START → AUDIO → STREAM_STOP` 首次会话完整可用。
 - [ ] 在 Windows 真机验证 WASAPI 端点初始化、VB-CABLE 回环、欠载恢复与完整尾音。
 - [x] CABLE Input 双层静音自愈：端点主静音使用 `IAudioEndpointVolume`；音量合成器里的 SayAll 应用会话静音使用 `ISimpleAudioVolume`，只匹配当前进程在已选 CABLE 端点上的会话。初始化、会话开始、流启动后检查，推流期间每 100ms 低频检查，必要时解除静音并读回；两层均不修改音量。2026-09-07 Windows 真实 CABLE Input 受控复现 passed：端点 open/begin 两检查点，以及应用会话 begin/after_start/stream_watch 三检查点均成功从 muted 恢复到 unmuted；随后真实 RC001 连续 9 次语音均复现“流启动约半秒后会话被外部重新静音”，监视路径 9/9 捕获并恢复为 unmuted（2765 个音频包），9 次开始/停止与快捷键按下/释放均成对；修复版 NSIS 本地包由用户复测确认 RC001 语音功能 passed。边界：完整 RC003 → CABLE → 输入法语音链仍按上一项真机验收。
+- [x] 生产诊断日志默认持久化到 LocalAppData：覆盖进程/Tauri/前端/Vue/首次 IPC 启动链，音频端点枚举与 `virtual_cable|bluetooth|other` 脱敏分类、WASAPI 打开/自动转换/推流/排空/中止/失败，以及按键映射和按住说话快捷键的加载、保存、重置；禁止原始音频包、端点名称/ID、自定义应用路径和异常正文进入生产日志。2026-09-08 自动化验证 passed；真实蓝牙耳机故障复现与安装包白屏现场日志验收 deferred。
 - [x] 在可见 NSIS 安装完成后检测 VB-CABLE 服务，未安装时说明第三方来源、管理员权限和重启要求并打开官方下载页；应用首次启动复检唯一 CABLE Input 并在无既有选择时自动配置。静默安装不打开网页，真实安装/重启仍待真机验收。
 - [ ] 如未来需要捆绑或自动执行 VB-CABLE 驱动包，先取得与 Pack45 内附许可一致的作者书面授权，并实现来源校验、显式 UAC、结果检测和重启流程。
 - [x] 持久化用户选择的输出端点，并在端点消失或更名时失败关闭；Windows 运行时恢复仍待真机验收。

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -20,4 +20,10 @@
 
 ## 日志与报告
 
+正式版无需额外开关，诊断日志位于
+`%LOCALAPPDATA%\SayAll\Logs\sayall-diagnostic.log`。复现问题后退出应用，再复制该
+文件；不要编辑后覆盖原件。白屏问题先看最后一次启动是否依次出现
+`process_start`、`tauri_setup`、`script_evaluation`、`vue_mount` 和
+`runtime_snapshot`，缺失的下一阶段就是优先排查边界。
+
 日志收集必须遵守 [LOGGING.md](LOGGING.md)，发布问题按 [Bugs/README.md](Bugs/README.md) 建立独立记录。报告中区分 `passed`、`failed`、`deferred`，不提交语音内容、个人路径、设备身份或凭据。

--- a/crates/sayall-windows/src/audio.rs
+++ b/crates/sayall-windows/src/audio.rs
@@ -1,6 +1,7 @@
 use crate::{AudioEndpoint, AudioPhase, AudioSnapshot, PlatformError};
 use std::collections::VecDeque;
 use std::sync::{
+    atomic::{AtomicU64, Ordering},
     mpsc::{self, Receiver, Sender, SyncSender},
     Arc, Mutex, MutexGuard,
 };
@@ -19,6 +20,7 @@ const POLL_INTERVAL: Duration = Duration::from_millis(5);
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 const DRAIN_TIMEOUT: Duration = Duration::from_secs(3);
 const SESSION_MUTE_WATCH_INTERVAL: Duration = Duration::from_millis(100);
+static AUDIO_ATTEMPT_SEQUENCE: AtomicU64 = AtomicU64::new(1);
 
 pub struct AudioRuntime {
     sender: SyncSender<AudioMessage>,
@@ -184,10 +186,17 @@ enum AudioMessage {
 }
 
 fn worker_loop(receiver: Receiver<AudioMessage>, state: Arc<Mutex<AudioSnapshot>>) {
+    crate::ble::gatt_note(
+        "audio_worker phase=started backend=wasapi direction=render sample_rate=16000 channels=1 sample_format=s16".to_owned(),
+    );
     if let Err(error) = wasapi::initialize_mta().ok() {
         *lock(&state) = failed_snapshot(format!("WASAPI COM 初始化失败：{error}"));
+        crate::ble::gatt_note(
+            "audio_worker phase=completed terminal_result=failed error_domain=com error_code=initialize_mta_failed reason=wasapi_apartment_unavailable retryable=false".to_owned(),
+        );
         return;
     }
+    crate::ble::gatt_note("audio_worker phase=ready result=passed com_apartment=mta".to_owned());
     let _apartment = WasapiApartment;
     let mut sink: Option<AudioSink> = None;
     let mut queue = VecDeque::<i16>::new();
@@ -211,29 +220,76 @@ fn worker_loop(receiver: Receiver<AudioMessage>, state: Arc<Mutex<AudioSnapshot>
         if let Some(message) = message {
             match message {
                 AudioMessage::ListEndpoints { reply } => {
-                    let _ = reply.send(list_endpoints());
+                    let started = Instant::now();
+                    crate::ble::gatt_note("audio_endpoint action=list phase=requested".to_owned());
+                    let result = list_endpoints();
+                    match &result {
+                        Ok(endpoints) => {
+                            let cable_count = endpoints
+                                .iter()
+                                .filter(|endpoint| endpoint.is_virtual_cable_candidate)
+                                .count();
+                            let bluetooth_count = endpoints
+                                .iter()
+                                .filter(|endpoint| endpoint_kind(&endpoint.id, &endpoint.name) == "bluetooth")
+                                .count();
+                            let inactive_counts = render_endpoint_inactive_counts().ok();
+                            let (disabled_count, unplugged_count, not_present_count) =
+                                inactive_counts.unwrap_or((0, 0, 0));
+                            crate::ble::gatt_note(format!(
+                                "audio_endpoint action=list phase=completed terminal_result=passed active_count={} active_virtual_cable_count={cable_count} active_bluetooth_count={bluetooth_count} active_other_count={} inactive_state_observed={} disabled_count={disabled_count} unplugged_count={unplugged_count} not_present_count={not_present_count} elapsed_ms={}",
+                                endpoints.len(),
+                                endpoints.len().saturating_sub(cable_count + bluetooth_count),
+                                inactive_counts.is_some(),
+                                started.elapsed().as_millis()
+                            ));
+                        }
+                        Err(_) => crate::ble::gatt_note(format!(
+                            "audio_endpoint action=list phase=completed terminal_result=failed error_domain=wasapi error_code=enumeration_failed reason=render_endpoint_enumeration_failed retryable=true elapsed_ms={}",
+                            started.elapsed().as_millis()
+                        )),
+                    }
+                    let _ = reply.send(result);
                 }
                 AudioMessage::SelectEndpoint { endpoint_id, reply } => {
+                    let started = Instant::now();
+                    let attempt_id = AUDIO_ATTEMPT_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+                    crate::ble::gatt_note(format!(
+                        "audio_endpoint attempt_id={attempt_id} action=select phase=requested source=user"
+                    ));
                     if pending_drain.is_some()
                         || matches!(
                             lock(&state).phase,
                             AudioPhase::Streaming | AudioPhase::Draining
                         )
                     {
+                        crate::ble::gatt_note(format!(
+                            "audio_endpoint attempt_id={attempt_id} action=select phase=completed terminal_result=failed error_domain=state error_code=audio_busy reason=active_voice_session retryable=true elapsed_ms={}",
+                            started.elapsed().as_millis()
+                        ));
                         let _ = reply.send(Err(PlatformError::AudioBusy));
                         continue;
                     }
                     sink = None;
                     queue.clear();
-                    match AudioSink::open(&endpoint_id) {
+                    match AudioSink::open(&endpoint_id, attempt_id) {
                         Ok(opened) => {
+                            let kind = endpoint_kind(&endpoint_id, &opened.name);
                             let snapshot = ready_snapshot(endpoint_id, opened.name.clone());
                             sink = Some(opened);
                             *lock(&state) = snapshot.clone();
+                            crate::ble::gatt_note(format!(
+                                "audio_endpoint attempt_id={attempt_id} action=select phase=completed terminal_result=passed endpoint_kind={kind} format_autoconvert=true sample_rate=16000 channels=1 elapsed_ms={}",
+                                started.elapsed().as_millis()
+                            ));
                             let _ = reply.send(Ok(snapshot));
                         }
                         Err(error) => {
                             *lock(&state) = failed_snapshot(error.to_string());
+                            crate::ble::gatt_note(format!(
+                                "audio_endpoint attempt_id={attempt_id} action=select phase=completed terminal_result=failed error_domain=wasapi error_code=open_failed reason=endpoint_format_or_state_unavailable retryable=true elapsed_ms={}",
+                                started.elapsed().as_millis()
+                            ));
                             let _ = reply.send(Err(error));
                         }
                     }
@@ -258,6 +314,10 @@ fn worker_loop(receiver: Receiver<AudioMessage>, state: Arc<Mutex<AudioSnapshot>
                     let _ = reply.send(Ok(snapshot));
                 }
                 AudioMessage::BeginSession { generation, reply } => {
+                    let started = Instant::now();
+                    crate::ble::gatt_note(format!(
+                        "audio_session generation={generation} action=begin phase=requested"
+                    ));
                     let result = begin_session(&mut sink, &mut queue, &state, generation);
                     if let Err(error @ PlatformError::Audio(_)) = &result {
                         fail_audio(
@@ -268,6 +328,18 @@ fn worker_loop(receiver: Receiver<AudioMessage>, state: Arc<Mutex<AudioSnapshot>
                             &mut pending_drain,
                         );
                     }
+                    crate::ble::gatt_note(match &result {
+                        Ok(snapshot) => format!(
+                            "audio_session generation={generation} action=begin phase=completed terminal_result=passed queued_samples={} elapsed_ms={}",
+                            snapshot.queued_samples,
+                            started.elapsed().as_millis()
+                        ),
+                        Err(error) => format!(
+                            "audio_session generation={generation} action=begin phase=completed terminal_result=failed error_domain=audio error_code={} reason=begin_rejected retryable=true elapsed_ms={}",
+                            audio_error_code(error),
+                            started.elapsed().as_millis()
+                        ),
+                    });
                     let _ = reply.send(result);
                 }
                 AudioMessage::Samples {
@@ -280,16 +352,32 @@ fn worker_loop(receiver: Receiver<AudioMessage>, state: Arc<Mutex<AudioSnapshot>
                     }
                 },
                 AudioMessage::FinishSession { generation, reply } => {
+                    crate::ble::gatt_note(format!(
+                        "audio_session generation={generation} action=finish phase=requested queued_samples={} submitted_samples={}",
+                        queue.len(),
+                        lock(&state).submitted_samples
+                    ));
                     let snapshot = lock(&state).clone();
                     if snapshot.phase != AudioPhase::Streaming || snapshot.generation != generation
                     {
                         let _ = reply.send(Err(PlatformError::AudioSessionMismatch));
+                        crate::ble::gatt_note(format!(
+                            "audio_session generation={generation} action=finish phase=completed terminal_result=failed error_domain=state error_code=session_mismatch reason=stale_or_duplicate_finish retryable=false"
+                        ));
                         continue;
                     }
                     lock(&state).phase = AudioPhase::Draining;
                     pending_drain = Some((generation, reply));
                 }
                 AudioMessage::Interrupt { reply } => {
+                    let generation = lock(&state).generation;
+                    let started = Instant::now();
+                    crate::ble::gatt_note(format!(
+                        "audio_session generation={} action=interrupt phase=requested queued_samples={} submitted_samples={}",
+                        lock(&state).generation,
+                        queue.len(),
+                        lock(&state).submitted_samples
+                    ));
                     if let Some((_, pending_reply)) = pending_drain.take() {
                         let _ = pending_reply.send(Err(PlatformError::AudioSessionInterrupted));
                     }
@@ -303,9 +391,24 @@ fn worker_loop(receiver: Receiver<AudioMessage>, state: Arc<Mutex<AudioSnapshot>
                             &mut pending_drain,
                         );
                     }
+                    crate::ble::gatt_note(match &result {
+                        Ok(snapshot) => format!(
+                            "audio_session generation={generation} action=interrupt phase=completed terminal_result=passed next_phase={} elapsed_ms={}",
+                            audio_phase_name(snapshot.phase),
+                            started.elapsed().as_millis()
+                        ),
+                        Err(error) => format!(
+                            "audio_session generation={generation} action=interrupt phase=completed terminal_result=failed error_domain=audio error_code={} reason=reset_failed retryable=true elapsed_ms={}",
+                            audio_error_code(error),
+                            started.elapsed().as_millis()
+                        ),
+                    });
                     let _ = reply.send(result);
                 }
                 AudioMessage::Shutdown => {
+                    crate::ble::gatt_note(
+                        "audio_worker phase=stopping reason=app_shutdown".to_owned(),
+                    );
                     if let Some((_, pending_reply)) = pending_drain.take() {
                         let _ = pending_reply.send(Err(PlatformError::AudioWorkerUnavailable));
                     }
@@ -348,6 +451,16 @@ fn worker_loop(receiver: Receiver<AudioMessage>, state: Arc<Mutex<AudioSnapshot>
                             &mut pending_drain,
                         );
                     }
+                    crate::ble::gatt_note(match &result {
+                        Ok(snapshot) => format!(
+                            "audio_session generation={generation} action=finish phase=completed terminal_result=passed submitted_samples={} queued_samples={}",
+                            snapshot.submitted_samples, snapshot.queued_samples
+                        ),
+                        Err(error) => format!(
+                            "audio_session generation={generation} action=finish phase=completed terminal_result=failed error_domain=audio error_code={} reason=drain_or_reset_failed retryable=true",
+                            audio_error_code(error)
+                        ),
+                    });
                     let _ = reply.send(result);
                 }
                 Ok(false) => pending_drain = Some((generation, reply)),
@@ -364,6 +477,49 @@ fn worker_loop(receiver: Receiver<AudioMessage>, state: Arc<Mutex<AudioSnapshot>
                 }
             }
         }
+    }
+    crate::ble::gatt_note("audio_worker phase=completed terminal_result=passed".to_owned());
+}
+
+fn endpoint_kind(endpoint_id: &str, name: &str) -> &'static str {
+    if crate::is_virtual_cable_output_name(name) {
+        return "virtual_cable";
+    }
+    let normalized_name = name.to_ascii_lowercase();
+    let normalized_id = endpoint_id.to_ascii_lowercase();
+    if normalized_id.contains("bthenum")
+        || normalized_id.contains("bluetooth")
+        || normalized_name.contains("bluetooth")
+        || normalized_name.contains("蓝牙")
+    {
+        "bluetooth"
+    } else {
+        "other"
+    }
+}
+
+fn audio_error_code(error: &PlatformError) -> &'static str {
+    match error {
+        PlatformError::AudioEndpointNotSelected => "endpoint_not_selected",
+        PlatformError::AudioBusy => "audio_busy",
+        PlatformError::AudioQueueOverflow => "queue_overflow",
+        PlatformError::AudioWorkerUnavailable => "worker_unavailable",
+        PlatformError::AudioOperationTimedOut => "operation_timed_out",
+        PlatformError::AudioSessionMismatch => "session_mismatch",
+        PlatformError::AudioSessionInterrupted => "session_interrupted",
+        PlatformError::Audio(_) => "wasapi_failure",
+        _ => "platform_failure",
+    }
+}
+
+fn audio_phase_name(phase: AudioPhase) -> &'static str {
+    match phase {
+        AudioPhase::Unconfigured => "unconfigured",
+        AudioPhase::Ready => "ready",
+        AudioPhase::Streaming => "streaming",
+        AudioPhase::Draining => "draining",
+        AudioPhase::Failed => "failed",
+        AudioPhase::Unsupported => "unsupported",
     }
 }
 
@@ -397,12 +553,37 @@ fn list_endpoints() -> Result<Vec<AudioEndpoint>, PlatformError> {
     Ok(endpoints)
 }
 
+fn render_endpoint_inactive_counts() -> windows::core::Result<(u32, u32, u32)> {
+    use windows::Win32::Media::Audio::{
+        eRender, IMMDeviceEnumerator, MMDeviceEnumerator, DEVICE_STATE_DISABLED,
+        DEVICE_STATE_NOTPRESENT, DEVICE_STATE_UNPLUGGED,
+    };
+    use windows::Win32::System::Com::{CoCreateInstance, CLSCTX_ALL};
+
+    let enumerator: IMMDeviceEnumerator =
+        unsafe { CoCreateInstance(&MMDeviceEnumerator, None, CLSCTX_ALL) }?;
+    let count = |state| -> windows::core::Result<u32> {
+        let collection = unsafe { enumerator.EnumAudioEndpoints(eRender, state) }?;
+        unsafe { collection.GetCount() }
+    };
+    Ok((
+        count(DEVICE_STATE_DISABLED)?,
+        count(DEVICE_STATE_UNPLUGGED)?,
+        count(DEVICE_STATE_NOTPRESENT)?,
+    ))
+}
+
 fn restore_endpoint(
     sink: &mut Option<AudioSink>,
     state: &Arc<Mutex<AudioSnapshot>>,
     endpoint_id: String,
     expected_name: String,
 ) -> AudioSnapshot {
+    let started = Instant::now();
+    let attempt_id = AUDIO_ATTEMPT_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    crate::ble::gatt_note(format!(
+        "audio_endpoint attempt_id={attempt_id} action=restore phase=requested source=persisted_settings"
+    ));
     let endpoints = match list_endpoints() {
         Ok(endpoints) => endpoints,
         Err(error) => {
@@ -412,20 +593,33 @@ fn restore_endpoint(
                 format!("无法验证上次选择的输出端点：{error}"),
             );
             *lock(state) = snapshot.clone();
+            crate::ble::gatt_note(format!(
+                "audio_endpoint attempt_id={attempt_id} action=restore phase=completed terminal_result=failed error_domain=wasapi error_code=enumeration_failed reason=cannot_validate_persisted_endpoint retryable=true elapsed_ms={}",
+                started.elapsed().as_millis()
+            ));
             return snapshot;
         }
     };
     if let Err(error) = validate_restored_endpoint(&endpoints, &endpoint_id, &expected_name) {
         let snapshot = configured_failure_snapshot(endpoint_id, expected_name, error);
         *lock(state) = snapshot.clone();
+        crate::ble::gatt_note(format!(
+            "audio_endpoint attempt_id={attempt_id} action=restore phase=completed terminal_result=failed error_domain=settings error_code=endpoint_identity_mismatch reason=persisted_endpoint_missing_or_changed retryable=true elapsed_ms={}",
+            started.elapsed().as_millis()
+        ));
         return snapshot;
     }
 
-    match AudioSink::open(&endpoint_id) {
+    match AudioSink::open(&endpoint_id, attempt_id) {
         Ok(opened) => {
+            let kind = endpoint_kind(&endpoint_id, &opened.name);
             let snapshot = ready_snapshot(endpoint_id, opened.name.clone());
             *sink = Some(opened);
             *lock(state) = snapshot.clone();
+            crate::ble::gatt_note(format!(
+                "audio_endpoint attempt_id={attempt_id} action=restore phase=completed terminal_result=passed endpoint_kind={kind} elapsed_ms={}",
+                started.elapsed().as_millis()
+            ));
             snapshot
         }
         Err(error) => {
@@ -435,6 +629,10 @@ fn restore_endpoint(
                 format!("恢复上次选择的输出端点失败：{error}"),
             );
             *lock(state) = snapshot.clone();
+            crate::ble::gatt_note(format!(
+                "audio_endpoint attempt_id={attempt_id} action=restore phase=completed terminal_result=failed error_domain=wasapi error_code=open_failed reason=persisted_endpoint_unavailable retryable=true elapsed_ms={}",
+                started.elapsed().as_millis()
+            ));
             snapshot
         }
     }
@@ -587,6 +785,24 @@ fn fail_audio(
     error: PlatformError,
     pending_drain: &mut Option<(u64, Sender<Result<AudioSnapshot, PlatformError>>)>,
 ) {
+    let snapshot_before = lock(state).clone();
+    if matches!(
+        snapshot_before.phase,
+        AudioPhase::Streaming | AudioPhase::Draining
+    ) {
+        crate::ble::gatt_note(format!(
+            "audio_session generation={} action=stream phase=completed terminal_result=failed error_domain=audio error_code={} reason=wasapi_pipeline_failed retryable=true queued_samples={} submitted_samples={}",
+            snapshot_before.generation,
+            audio_error_code(&error),
+            queue.len(),
+            snapshot_before.submitted_samples
+        ));
+    } else {
+        crate::ble::gatt_note(format!(
+            "audio_pipeline event=failure phase=observed error_domain=audio error_code={} reason=pre_stream_failure retryable=true",
+            audio_error_code(&error)
+        ));
+    }
     if let Some((_, reply)) = pending_drain.take() {
         let _ = reply.send(Err(error.clone()));
     }
@@ -610,7 +826,7 @@ struct AudioSink {
 }
 
 impl AudioSink {
-    fn open(endpoint_id: &str) -> Result<Self, PlatformError> {
+    fn open(endpoint_id: &str, attempt_id: u64) -> Result<Self, PlatformError> {
         let enumerator =
             DeviceEnumerator::new().map_err(|error| audio_error("创建端点枚举器", error))?;
         let device = enumerator
@@ -620,6 +836,10 @@ impl AudioSink {
             .get_friendlyname()
             .map_err(|error| audio_error("读取所选端点名称", error))?;
         let is_virtual_cable = crate::is_virtual_cable_output_name(&name);
+        crate::ble::gatt_note(format!(
+            "audio_endpoint attempt_id={attempt_id} action=open phase=properties_read result=passed endpoint_kind={} virtual_cable={is_virtual_cable}",
+            endpoint_kind(endpoint_id, &name)
+        ));
         ensure_cable_endpoint_unmuted(endpoint_id, is_virtual_cable, "open")?;
         let mut client = device
             .get_iaudioclient()
@@ -645,6 +865,9 @@ impl AudioSink {
                 },
             )
             .map_err(|error| audio_error("初始化 16 kHz WASAPI 输出", error))?;
+        crate::ble::gatt_note(format!(
+            "audio_endpoint attempt_id={attempt_id} action=open phase=client_initialized result=passed share_mode=shared autoconvert=true requested_sample_rate=16000 requested_channels=1 buffer_period_hns={default_period}"
+        ));
         if is_virtual_cable {
             client
                 .get_audiosessioncontrol()
@@ -772,6 +995,10 @@ impl AudioSink {
                 .start_stream()
                 .map_err(|error| audio_error("启动 WASAPI 音频流", error))?;
             self.started = true;
+            crate::ble::gatt_note(format!(
+                "audio_stream phase=started result=passed endpoint_kind={} prebuffer_samples={PREBUFFER_SAMPLES} first_write_frames={frames}",
+                endpoint_kind(&self.endpoint_id, &self.name)
+            ));
             self.ensure_session_unmuted("after_start", true)?;
         }
         Ok(frames)
@@ -879,7 +1106,7 @@ fn ensure_cable_endpoint_unmuted(
         }
         Err(error) => {
             crate::ble::gatt_note(format!(
-                "endpoint_unmute checkpoint={checkpoint} result=failed elapsed_ms={} err={error}",
+                "endpoint_unmute checkpoint={checkpoint} result=failed error_domain=wasapi error_code=endpoint_volume_failed reason=mute_state_unavailable retryable=true elapsed_ms={}",
                 started.elapsed().as_millis()
             ));
             Err(audio_error("检查并恢复 CABLE Input 静音状态", error))
@@ -1069,6 +1296,21 @@ mod tests {
                 .unwrap_err()
                 .contains("名称已变")
         );
+    }
+
+    #[test]
+    fn endpoint_logging_classifies_bluetooth_without_returning_identity() {
+        assert_eq!(
+            endpoint_kind("{0.0.0.00000000}.bthenum-device", "Headphones"),
+            "bluetooth"
+        );
+        assert_eq!(endpoint_kind("opaque-id", "Bluetooth Headset"), "bluetooth");
+        assert_eq!(endpoint_kind("opaque-id", "蓝牙耳机"), "bluetooth");
+        assert_eq!(
+            endpoint_kind("opaque-id", "CABLE Input (VB-Audio Virtual Cable)"),
+            "virtual_cable"
+        );
+        assert_eq!(endpoint_kind("opaque-id", "Speakers"), "other");
     }
 
     #[cfg(windows)]

--- a/crates/sayall-windows/src/ble.rs
+++ b/crates/sayall-windows/src/ble.rs
@@ -552,9 +552,9 @@ fn worker_loop(
                                     &voice_session_epoch,
                                 );
                             }
-                            Err(error) => {
+                            Err(_) => {
                                 gatt_note(format!(
-                                    "chord_retry result=err attempt={attempt} epoch={epoch} err={error}"
+                                    "chord_retry result=err attempt={attempt} epoch={epoch} error_domain=send_input error_code=retry_failed reason=injection_failed retryable=true"
                                 ));
                             }
                         }
@@ -1034,7 +1034,7 @@ fn handle_control(
                 }
                 if let Err(error) = send_input.press(&chord) {
                     gatt_note(format!(
-                        "chord_press result=err session={session_id} err={error}"
+                        "chord_press result=err session={session_id} error_domain=send_input error_code=press_failed reason=injection_failed retryable=true"
                     ));
                     abort_voice_session(
                         session,
@@ -1067,7 +1067,7 @@ fn handle_control(
             }
             if let Err(error) = audio.begin_session(generation) {
                 gatt_note(format!(
-                    "audio_begin result=err session={session_id} err={error}"
+                    "audio_begin result=err session={session_id} error_domain=audio error_code=begin_failed reason=wasapi_rejected retryable=true"
                 ));
                 abort_voice_session(
                     session,
@@ -1235,12 +1235,20 @@ fn release_voice_hold_hotkey(send_input: &SendInputRuntime, held_hotkey: &mut Op
         // 功能点日志：释放结果（与 chord_press 成对，粘键排查的另一半）。
         let result = send_input.release(&chord);
         gatt_note(format!(
-            "chord_release result={} err={}",
+            "chord_release result={} error_domain={} error_code={} reason={} retryable={}",
             if result.is_ok() { "ok" } else { "err" },
-            result
-                .err()
-                .map(|error| error.to_string())
-                .unwrap_or_default(),
+            if result.is_ok() { "none" } else { "send_input" },
+            if result.is_ok() {
+                "none"
+            } else {
+                "release_failed"
+            },
+            if result.is_ok() {
+                "released"
+            } else {
+                "backend_rejected"
+            },
+            result.is_err(),
         ));
     }
 }
@@ -1294,17 +1302,17 @@ impl BleSession {
                     gatt_note("conn_params result=ok mode=throughput_optimized".to_owned());
                     Some(request)
                 }
-                Err(error) => {
-                    gatt_note(format!(
-                        "conn_params result=unavailable err={error} mode=throughput_optimized"
-                    ));
+                Err(_) => {
+                    gatt_note(
+                        "conn_params result=unavailable error_domain=bluetooth error_code=request_failed reason=connection_parameter_api_failed retryable=true mode=throughput_optimized".to_owned(),
+                    );
                     None
                 }
             },
-            Err(error) => {
-                gatt_note(format!(
-                    "conn_params result=unavailable err={error} mode=throughput_optimized"
-                ));
+            Err(_) => {
+                gatt_note(
+                    "conn_params result=unavailable error_domain=bluetooth error_code=request_failed reason=connection_parameter_api_failed retryable=true mode=throughput_optimized".to_owned(),
+                );
                 None
             }
         };
@@ -1516,14 +1524,46 @@ enum WorkerChannel {
     Control,
 }
 
-/// ATVV 诊断日志（环境变量 SAYALL_GATT_LOG=<文件路径> 开启，默认关闭）：
-/// 记录每条 GATT 通知（A=音频/C=控制）与应用发出的每条 TRANSMIT 写入（T），
-/// 含墙钟毫秒、长度与前 24 字节十六进制。用于 RC001/RC003 报文格式取证，
-/// 不含设备身份信息。
+#[derive(Debug, Clone)]
+pub struct DiagnosticLogMetadata {
+    pub app_version: String,
+    pub app_build: String,
+    pub source_revision: String,
+    pub build_channel: String,
+    pub release_tag: String,
+}
+
+static DIAGNOSTIC_LOG_PATH: OnceLock<std::path::PathBuf> = OnceLock::new();
+static DIAGNOSTIC_LOG_METADATA: OnceLock<DiagnosticLogMetadata> = OnceLock::new();
+
+/// 在任何功能组件启动前配置生产诊断日志。环境变量仍可覆盖路径，方便受控取证；
+/// 正式应用由宿主传入 LocalAppData 下的固定路径，日志内容绝不打印该路径。
+pub fn initialize_diagnostic_log(
+    default_path: std::path::PathBuf,
+    metadata: DiagnosticLogMetadata,
+) -> bool {
+    let path = std::env::var_os("SAYALL_GATT_LOG")
+        .map(std::path::PathBuf::from)
+        .unwrap_or(default_path);
+    let parent_ready = path
+        .parent()
+        .map(|parent| std::fs::create_dir_all(parent).is_ok())
+        .unwrap_or(false);
+    let _ = DIAGNOSTIC_LOG_PATH.set(path);
+    let _ = DIAGNOSTIC_LOG_METADATA.set(metadata);
+    parent_ready && gatt_sink().is_some()
+}
+
+/// ATVV 诊断日志（宿主默认写入 LocalAppData；SAYALL_GATT_LOG 可覆盖路径）。
+/// 控制通知与 TRANSMIT 写入保留长度及有限预览用于协议取证；音频通知不在这里
+/// 逐包落盘，防止泄露语音内容并避免高频刷盘，改由音频会话终态聚合记录。
 fn gatt_sink() -> Option<&'static Mutex<std::fs::File>> {
     static SINK: OnceLock<Option<Mutex<std::fs::File>>> = OnceLock::new();
     SINK.get_or_init(|| {
-        let path = std::env::var_os("SAYALL_GATT_LOG")?;
+        let path = DIAGNOSTIC_LOG_PATH
+            .get()
+            .cloned()
+            .or_else(|| std::env::var_os("SAYALL_GATT_LOG").map(std::path::PathBuf::from))?;
         std::fs::OpenOptions::new()
             .create(true)
             .append(true)
@@ -1536,19 +1576,34 @@ fn gatt_sink() -> Option<&'static Mutex<std::fs::File>> {
 
 fn gatt_log(kind: &str, bytes: &[u8]) {
     use std::io::Write as _;
+    // 原始音频包既是高频数据又可能承载语音内容，生产诊断日志绝不落盘。
+    // 会话级音频统计由 audio.rs 在开始、排空、失败时聚合记录。
+    if kind == "A" {
+        return;
+    }
     if let Some(sink) = gatt_sink() {
         if let Ok(mut file) = sink.lock() {
-            let now_ms = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|duration| duration.as_millis())
-                .unwrap_or(0);
+            let timestamp = utc_timestamp();
+            let metadata = DIAGNOSTIC_LOG_METADATA.get();
             let preview: String = bytes
                 .iter()
                 .take(24)
                 .map(|byte| format!("{byte:02X}"))
                 .collect::<Vec<_>>()
                 .join(" ");
-            let _ = writeln!(file, "{kind} {now_ms} len={:3} b=[{preview}]", bytes.len());
+            let _ = writeln!(
+                file,
+                "{timestamp} pid={} ver={} build={} component=gatt event=packet direction={kind} byte_count={} preview=[{preview}]",
+                std::process::id(),
+                metadata
+                    .map(|value| value.app_version.as_str())
+                    .unwrap_or("unknown"),
+                metadata
+                    .map(|value| value.app_build.as_str())
+                    .unwrap_or("unknown"),
+                bytes.len()
+            );
+            let _ = file.flush();
         }
     }
 }
@@ -1563,13 +1618,53 @@ pub fn gatt_note(note: String) {
     use std::io::Write as _;
     if let Some(sink) = gatt_sink() {
         if let Ok(mut file) = sink.lock() {
-            let now_ms = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|duration| duration.as_millis())
-                .unwrap_or(0);
-            let _ = writeln!(file, "N {now_ms} len=  0 note={note}");
+            let timestamp = utc_timestamp();
+            let metadata = DIAGNOSTIC_LOG_METADATA.get();
+            let _ = writeln!(
+                file,
+                "{timestamp} pid={} ver={} build={} source_revision={} build_channel={} release_tag={} {note}",
+                std::process::id(),
+                metadata.map(|value| value.app_version.as_str()).unwrap_or("unknown"),
+                metadata.map(|value| value.app_build.as_str()).unwrap_or("unknown"),
+                metadata.map(|value| value.source_revision.as_str()).unwrap_or("unknown"),
+                metadata.map(|value| value.build_channel.as_str()).unwrap_or("unknown"),
+                metadata.map(|value| value.release_tag.as_str()).unwrap_or("unknown"),
+            );
+            let _ = file.flush();
         }
     }
+}
+
+fn utc_timestamp() -> String {
+    let duration = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    format_utc_timestamp(duration)
+}
+
+fn format_utc_timestamp(duration: std::time::Duration) -> String {
+    let total_seconds = duration.as_secs() as i64;
+    let days = total_seconds.div_euclid(86_400);
+    let seconds_of_day = total_seconds.rem_euclid(86_400);
+    // Howard Hinnant 的 civil_from_days 算法；避免为日志时间戳引入运行时依赖。
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let day_of_era = z - era * 146_097;
+    let year_of_era =
+        (day_of_era - day_of_era / 1_460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let mut year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let month_prime = (5 * day_of_year + 2) / 153;
+    let day = day_of_year - (153 * month_prime + 2) / 5 + 1;
+    let month = month_prime + if month_prime < 10 { 3 } else { -9 };
+    year += i64::from(month <= 2);
+    let hour = seconds_of_day / 3_600;
+    let minute = (seconds_of_day % 3_600) / 60;
+    let second = seconds_of_day % 60;
+    format!(
+        "{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{:03}Z",
+        duration.subsec_millis()
+    )
 }
 
 /// WeType 热键休眠检测与同一次按住内的自动恢复（2026-09-05 实证闭环）：
@@ -1942,6 +2037,18 @@ impl Drop for WinRtApartment {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn diagnostic_timestamp_is_utc_iso_8601_with_milliseconds() {
+        assert_eq!(
+            format_utc_timestamp(std::time::Duration::from_millis(0)),
+            "1970-01-01T00:00:00.000Z"
+        );
+        assert_eq!(
+            format_utc_timestamp(std::time::Duration::from_millis(1_773_446_400_123)),
+            "2026-03-14T00:00:00.123Z"
+        );
+    }
 
     #[test]
     fn reconnect_schedule_reports_attempt_and_exponential_delay() {

--- a/crates/sayall-windows/src/button_mapping.rs
+++ b/crates/sayall-windows/src/button_mapping.rs
@@ -580,21 +580,30 @@ fn fire_gesture(
             match injector.tap(&chord) {
                 Ok(()) => crate::ble::gatt_note("map_inject result=ok".to_owned()),
                 Err(error) => {
-                    crate::ble::gatt_note(format!("map_inject result=err error={error}"));
+                    crate::ble::gatt_note("map_inject result=err error_domain=send_input error_code=injection_failed reason=backend_rejected retryable=true".to_owned());
                     lock_state(state).last_error = Some(format!("注入快捷键失败：{error}"));
                 }
             }
         }
         ButtonAction::OpenApp { target } => {
+            let target_kind = if target.contains('\\') || target.contains('/') {
+                "custom"
+            } else {
+                "preset"
+            };
             crate::ble::gatt_note(format!(
-                "map_fire button={:?} trigger={:?} action=open_app target={target}",
-                button, trigger
+                "map_fire button={:?} trigger={:?} action=open_app target_kind={target_kind}",
+                button, trigger,
             ));
             match injector.launch_app(&target) {
-                Ok(()) => crate::ble::gatt_note(format!("map_launch result=ok target={target}")),
+                Ok(()) => crate::ble::gatt_note(format!(
+                    "map_launch result=ok target_kind={}",
+                    target_kind
+                )),
                 Err(error) => {
                     crate::ble::gatt_note(format!(
-                        "map_launch result=err target={target} error={error}"
+                        "map_launch result=err target_kind={} error_domain=shell error_code=launch_failed reason=target_unavailable retryable=true",
+                        target_kind
                     ));
                     lock_state(state).last_error = Some(format!("打开应用失败：{error}"));
                 }

--- a/crates/sayall-windows/src/ime.rs
+++ b/crates/sayall-windows/src/ime.rs
@@ -87,14 +87,17 @@ pub fn activate_wetype_session() -> Result<WeTypeActivation, String> {
     };
     // 功能点日志（AGENTS.md）：决策结果 + 耗时 + 前台进程，报障时一次
     // 日志拉取即可定位是热/冷路径、查询、激活还是等待环节。
+    let outcome = match &result {
+        Ok(WeTypeActivation::AlreadyActive) => "already_active",
+        Ok(WeTypeActivation::Switched) => "switched",
+        Err(_) => "failed",
+    };
     crate::ble::gatt_note(format!(
-        "ime_activation outcome={:?} elapsed_ms={} foreground={} err={}",
-        result
-            .as_ref()
-            .map(|outcome| format!("{outcome:?}"))
-            .unwrap_or_else(|error| error.clone()),
+        "ime_activation outcome={outcome} elapsed_ms={} foreground_observed={} error_domain={} error_code={} retryable={}",
         started.elapsed().as_millis(),
-        foreground_process_name().unwrap_or_else(|| "unknown".to_owned()),
+        foreground_process_name().is_some(),
+        if result.is_ok() { "none" } else { "tsf" },
+        if result.is_ok() { "none" } else { "activation_failed" },
         result.is_err(),
     ));
     result
@@ -269,11 +272,11 @@ fn sta_ensure_wetype() -> Result<WeTypeActivation, String> {
                 Ok(()) => profile.clsid == WETYPE_CLSID && profile.guidProfile == WETYPE_PROFILE,
                 Err(_) => false,
             };
-            // 功能点日志：查询结果（活动输入法 CLSID 前缀）——冷/热判定依据。
+            // 功能点日志：只记录冷/热判定，不落盘输入法 GUID 或前台应用身份。
             crate::ble::gatt_note(format!(
-                "ime_query ok={} active_is_wetype={active_is_wetype} active_clsid={:08X}",
+                "ime_query ok={} active_is_wetype={active_is_wetype} active_profile_present={}",
                 query.is_ok(),
-                profile.clsid.data1,
+                profile.clsid != GUID::from_u128(0),
             ));
             if active_is_wetype {
                 return Ok(WeTypeActivation::AlreadyActive);

--- a/crates/sayall-windows/src/lib.rs
+++ b/crates/sayall-windows/src/lib.rs
@@ -17,7 +17,7 @@ mod button_gestures;
 pub mod button_mapping;
 pub mod compatibility;
 #[cfg(windows)]
-pub use ble::gatt_note;
+pub use ble::{gatt_note, initialize_diagnostic_log, DiagnosticLogMetadata};
 #[cfg(windows)]
 mod ime;
 pub mod key_gate;

--- a/crates/sayall-windows/tests/diagnostic_log.rs
+++ b/crates/sayall-windows/tests/diagnostic_log.rs
@@ -1,0 +1,33 @@
+use sayall_windows::{gatt_note, initialize_diagnostic_log, DiagnosticLogMetadata};
+
+#[test]
+fn production_default_log_path_writes_structured_metadata_without_environment_override() {
+    let path = std::env::temp_dir().join(format!(
+        "sayall-production-log-test-{}.log",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&path);
+    // SAFETY: 集成测试拥有独立进程，只在初始化 OnceLock 前修改本进程环境。
+    unsafe { std::env::remove_var("SAYALL_GATT_LOG") };
+    assert!(initialize_diagnostic_log(
+        path.clone(),
+        DiagnosticLogMetadata {
+            app_version: "0.2.2-test".to_owned(),
+            app_build: "42".to_owned(),
+            source_revision: "0123456789012345678901234567890123456789".to_owned(),
+            build_channel: "local".to_owned(),
+            release_tag: "none".to_owned(),
+        },
+    ));
+    gatt_note("diagnostic_test phase=completed terminal_result=passed".to_owned());
+
+    let contents = std::fs::read_to_string(&path).expect("default diagnostic log was not written");
+    let _ = std::fs::remove_file(path);
+    assert!(
+        contents.starts_with("20"),
+        "missing UTC timestamp: {contents}"
+    );
+    assert!(contents.contains("ver=0.2.2-test build=42"));
+    assert!(contents.contains("build_channel=local release_tag=none"));
+    assert!(contents.contains("diagnostic_test phase=completed terminal_result=passed"));
+}

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,18 @@
 fn main() {
+    let revision = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|revision| revision.trim().to_owned())
+        .filter(|revision| revision.len() == 40)
+        .unwrap_or_else(|| "unknown".to_owned());
+    println!("cargo:rustc-env=SAYALL_SOURCE_REVISION={revision}");
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed=../.git/refs");
+    println!("cargo:rerun-if-changed=../.git/packed-refs");
+    println!("cargo:rerun-if-env-changed=SAYALL_BUILD_CHANNEL");
+    println!("cargo:rerun-if-env-changed=SAYALL_RELEASE_TAG");
     tauri_build::build()
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -222,33 +222,92 @@ async fn save_button_mappings(
     mappings: ButtonMappings,
     state: tauri::State<'_, AppState>,
 ) -> Result<ButtonMappings, String> {
+    let started = std::time::Instant::now();
+    let summary = button_mapping_log_summary(&mappings);
+    sayall_windows::gatt_note(format!(
+        "shortcut_settings feature=button_mapping action=save phase=requested {summary}"
+    ));
     let settings = state.settings.clone();
     let platform = Arc::clone(&state.platform);
-    let saved = tauri::async_runtime::spawn_blocking(move || -> Result<ButtonMappings, String> {
-        let saved = settings.save_button_mappings(mappings)?;
-        // 持久化成功后热加载到引擎与门控（保存即生效）。
-        platform.set_button_mappings(saved.clone());
-        Ok(saved)
-    })
-    .await
-    .map_err(|error| format!("保存按键映射任务失败：{error}"))??;
-    Ok(saved)
+    let result =
+        match tauri::async_runtime::spawn_blocking(move || -> Result<ButtonMappings, String> {
+            let saved = settings.save_button_mappings(mappings)?;
+            // 持久化成功后热加载到引擎与门控（保存即生效）。
+            platform.set_button_mappings(saved.clone());
+            Ok(saved)
+        })
+        .await
+        {
+            Ok(result) => result,
+            Err(error) => Err(format!("保存按键映射任务失败：{error}")),
+        };
+    sayall_windows::gatt_note(match &result {
+        Ok(saved) => format!(
+            "shortcut_settings feature=button_mapping action=save phase=completed terminal_result=passed {} elapsed_ms={}",
+            button_mapping_log_summary(saved),
+            started.elapsed().as_millis()
+        ),
+        Err(_) => format!(
+            "shortcut_settings feature=button_mapping action=save phase=completed terminal_result=failed error_domain=settings error_code=save_failed reason=validation_or_persistence_failed retryable=true elapsed_ms={}",
+            started.elapsed().as_millis()
+        ),
+    });
+    result
 }
 
 #[tauri::command]
 async fn reset_button_mappings(
     state: tauri::State<'_, AppState>,
 ) -> Result<ButtonMappings, String> {
+    let started = std::time::Instant::now();
+    sayall_windows::gatt_note(
+        "shortcut_settings feature=button_mapping action=reset phase=requested".to_owned(),
+    );
     let settings = state.settings.clone();
     let platform = Arc::clone(&state.platform);
-    let saved = tauri::async_runtime::spawn_blocking(move || -> Result<ButtonMappings, String> {
-        let saved = settings.save_button_mappings(ButtonMappings::default())?;
-        platform.set_button_mappings(saved.clone());
-        Ok(saved)
-    })
-    .await
-    .map_err(|error| format!("恢复默认按键映射任务失败：{error}"))??;
-    Ok(saved)
+    let result =
+        match tauri::async_runtime::spawn_blocking(move || -> Result<ButtonMappings, String> {
+            let saved = settings.save_button_mappings(ButtonMappings::default())?;
+            platform.set_button_mappings(saved.clone());
+            Ok(saved)
+        })
+        .await
+        {
+            Ok(result) => result,
+            Err(error) => Err(format!("恢复默认按键映射任务失败：{error}")),
+        };
+    sayall_windows::gatt_note(match &result {
+        Ok(saved) => format!(
+            "shortcut_settings feature=button_mapping action=reset phase=completed terminal_result=passed {} elapsed_ms={}",
+            button_mapping_log_summary(saved),
+            started.elapsed().as_millis()
+        ),
+        Err(_) => format!(
+            "shortcut_settings feature=button_mapping action=reset phase=completed terminal_result=failed error_domain=settings error_code=save_failed reason=defaults_persistence_failed retryable=true elapsed_ms={}",
+            started.elapsed().as_millis()
+        ),
+    });
+    result
+}
+
+fn button_mapping_log_summary(mappings: &ButtonMappings) -> String {
+    let mut shortcut_count = 0_usize;
+    let mut open_app_count = 0_usize;
+    let mut disabled_count = 0_usize;
+    for actions in mappings.actions.values() {
+        for action in [&actions.single, &actions.double, &actions.long] {
+            match action {
+                ButtonAction::Shortcut { .. } => shortcut_count += 1,
+                ButtonAction::OpenApp { .. } => open_app_count += 1,
+                ButtonAction::Disabled => disabled_count += 1,
+            }
+        }
+    }
+    format!(
+        "enabled={} button_count={} shortcut_count={shortcut_count} open_app_count={open_app_count} disabled_cell_count={disabled_count}",
+        mappings.enabled,
+        mappings.actions.len()
+    )
 }
 
 #[tauri::command]
@@ -305,7 +364,13 @@ fn get_send_input_snapshot(state: tauri::State<'_, AppState>) -> SendInputSnapsh
 
 #[tauri::command]
 fn get_voice_hold_hotkey(state: tauri::State<'_, AppState>) -> Option<KeyChord> {
-    state.platform.voice_hold_hotkey()
+    let hotkey = state.platform.voice_hold_hotkey();
+    sayall_windows::gatt_note(format!(
+        "shortcut_settings feature=voice_hold action=load phase=completed terminal_result=passed enabled={} key_count={}",
+        hotkey.is_some(),
+        hotkey.as_ref().map(|chord| chord.keys.len()).unwrap_or(0)
+    ));
+    hotkey
 }
 
 #[tauri::command]
@@ -313,15 +378,70 @@ async fn set_voice_hold_hotkey(
     hotkey: Option<KeyChord>,
     state: tauri::State<'_, AppState>,
 ) -> Result<Option<KeyChord>, String> {
+    let started = std::time::Instant::now();
+    let enabled = hotkey.is_some();
+    let key_count = hotkey.as_ref().map(|chord| chord.keys.len()).unwrap_or(0);
+    sayall_windows::gatt_note(format!(
+        "shortcut_settings feature=voice_hold action=save phase=requested enabled={enabled} key_count={key_count}"
+    ));
     let platform = Arc::clone(&state.platform);
     let settings = state.settings.clone();
-    tauri::async_runtime::spawn_blocking(move || {
+    let result = match tauri::async_runtime::spawn_blocking(move || {
         let saved = settings.save_voice_hold_hotkey(hotkey)?;
         platform.set_voice_hold_hotkey(saved.clone());
         Ok(saved)
     })
     .await
-    .map_err(|error| format!("保存按住说话快捷键任务失败：{error}"))?
+    {
+        Ok(result) => result,
+        Err(error) => Err(format!("保存按住说话快捷键任务失败：{error}")),
+    };
+    sayall_windows::gatt_note(match &result {
+        Ok(_) => format!(
+            "shortcut_settings feature=voice_hold action=save phase=completed terminal_result=passed enabled={enabled} key_count={key_count} elapsed_ms={}",
+            started.elapsed().as_millis()
+        ),
+        Err(_) => format!(
+            "shortcut_settings feature=voice_hold action=save phase=completed terminal_result=failed enabled={enabled} key_count={key_count} error_domain=settings error_code=save_failed reason=validation_or_persistence_failed retryable=true elapsed_ms={}",
+            started.elapsed().as_millis()
+        ),
+    });
+    result
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FrontendDiagnosticEvent {
+    event: String,
+    phase: String,
+    result: String,
+    reason: String,
+    elapsed_ms: u64,
+}
+
+#[tauri::command]
+fn report_frontend_event(report: FrontendDiagnosticEvent) {
+    sayall_windows::gatt_note(format!(
+        "frontend event={} phase={} result={} reason={} elapsed_ms={}",
+        diagnostic_token(&report.event),
+        diagnostic_token(&report.phase),
+        diagnostic_token(&report.result),
+        diagnostic_token(&report.reason),
+        report.elapsed_ms
+    ));
+}
+
+fn diagnostic_token(value: &str) -> &str {
+    if !value.is_empty()
+        && value.len() <= 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.'))
+    {
+        value
+    } else {
+        "invalid"
+    }
 }
 
 #[tauri::command]
@@ -588,8 +708,38 @@ fn runtime_simulation_requested() -> bool {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    let log_path = std::env::var_os("LOCALAPPDATA")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(std::env::temp_dir)
+        .join("SayAll")
+        .join("Logs")
+        .join("sayall-diagnostic.log");
+    let log_ready = sayall_windows::initialize_diagnostic_log(
+        log_path,
+        sayall_windows::DiagnosticLogMetadata {
+            app_version: env!("CARGO_PKG_VERSION").to_owned(),
+            app_build: option_env!("SAYALL_APP_BUILD")
+                .unwrap_or("unknown")
+                .to_owned(),
+            source_revision: env!("SAYALL_SOURCE_REVISION").to_owned(),
+            build_channel: option_env!("SAYALL_BUILD_CHANNEL")
+                .unwrap_or("unknown")
+                .to_owned(),
+            release_tag: option_env!("SAYALL_RELEASE_TAG")
+                .unwrap_or("unknown")
+                .to_owned(),
+        },
+    );
+    sayall_windows::gatt_note(format!(
+        "app_lifecycle event=process_start phase=started result={} diagnostic_schema=1 process_architecture={} windows_version=unknown windows_build=unknown",
+        if log_ready { "passed" } else { "failed" },
+        std::env::consts::ARCH
+    ));
     #[cfg(windows)]
     if let Err(error) = sayall_windows::compatibility::check_current_windows() {
+        sayall_windows::gatt_note(
+            "app_lifecycle event=compatibility_check phase=completed terminal_result=failed error_domain=windows error_code=unsupported_version reason=os_requirement_not_met retryable=false".to_owned(),
+        );
         sayall_windows::compatibility::show_unsupported_windows_message(error);
         eprintln!("{error}");
         return;
@@ -612,6 +762,9 @@ pub fn run() {
                 // CreateMutexW 对"已存在"返回有效句柄 + GetLastError=
                 // ERROR_ALREADY_EXISTS（不是失败）；其余残留错误值无意义。
                 if unsafe { GetLastError() } == ERROR_ALREADY_EXISTS {
+                    sayall_windows::gatt_note(
+                        "app_lifecycle event=single_instance phase=completed terminal_result=failed error_domain=process error_code=already_running reason=existing_instance retryable=false".to_owned(),
+                    );
                     eprintln!("SayAll 已在运行：单实例守卫阻止了第二个实例启动");
                     unsafe {
                         let _ = CloseHandle(handle);
@@ -620,8 +773,15 @@ pub fn run() {
                 }
                 // 故意持有互斥体句柄不关闭：进程存活期间保持占有，退出时由系统释放。
                 std::mem::forget(handle);
+                sayall_windows::gatt_note(
+                    "app_lifecycle event=single_instance phase=completed terminal_result=passed"
+                        .to_owned(),
+                );
             }
             Err(error) => {
+                sayall_windows::gatt_note(
+                    "app_lifecycle event=single_instance phase=completed terminal_result=failed error_domain=windows error_code=mutex_create_failed reason=guard_unavailable retryable=true".to_owned(),
+                );
                 eprintln!("单实例互斥体创建失败：{error}（fail-closed 退出）");
                 return;
             }
@@ -632,7 +792,20 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         // 应用内更新（GitHub Releases 静态 latest.json + minisign 验签）。
         .plugin(tauri_plugin_updater::Builder::new().build())
+        .on_page_load(|webview, payload| {
+            let phase = match payload.event() {
+                tauri::webview::PageLoadEvent::Started => "started",
+                tauri::webview::PageLoadEvent::Finished => "finished",
+            };
+            sayall_windows::gatt_note(format!(
+                "webview event=document_load phase={phase} result=passed main_window={}",
+                webview.label() == "main"
+            ));
+        })
         .setup(|app| {
+            sayall_windows::gatt_note(
+                "app_lifecycle event=tauri_setup phase=started result=passed".to_owned(),
+            );
             // 托盘图标：主窗口关闭后驻留；菜单 = 显示主界面 / 退出；
             // 左键点击托盘 = 显示并聚焦主窗口（Mac StatusIcon 同款行为）。
             #[cfg(all(windows, not(feature = "runtime-simulation")))]
@@ -694,16 +867,33 @@ pub fn run() {
             let settings_path = app.path().app_config_dir()?.join("settings.json");
             let settings = SettingsStore::new(settings_path);
             let saved_settings = match settings.load() {
-                Ok(settings) => settings,
+                Ok(settings) => {
+                    sayall_windows::gatt_note(
+                        "settings feature=application action=load phase=completed terminal_result=passed".to_owned(),
+                    );
+                    settings
+                }
                 Err(error) => {
+                    sayall_windows::gatt_note(
+                        "settings feature=application action=load phase=completed terminal_result=failed error_domain=settings error_code=parse_or_read_failed reason=defaults_applied retryable=true".to_owned(),
+                    );
                     eprintln!("{error}");
                     Default::default()
                 }
             };
             let platform = create_platform();
             let button_mappings = match settings.load_button_mappings() {
-                Ok(mappings) => mappings,
+                Ok(mappings) => {
+                    sayall_windows::gatt_note(format!(
+                        "shortcut_settings feature=button_mapping action=load phase=completed terminal_result=passed {}",
+                        button_mapping_log_summary(&mappings)
+                    ));
+                    mappings
+                }
                 Err(error) => {
+                    sayall_windows::gatt_note(
+                        "shortcut_settings feature=button_mapping action=load phase=completed terminal_result=failed error_domain=settings error_code=parse_or_read_failed reason=defaults_applied retryable=true".to_owned(),
+                    );
                     eprintln!("{error}");
                     ButtonMappings::default()
                 }
@@ -717,6 +907,9 @@ pub fn run() {
                 saved_settings.audio_endpoint_name,
             ) {
                 if let Err(error) = platform.restore_audio_endpoint(endpoint_id, endpoint_name) {
+                    sayall_windows::gatt_note(
+                        "audio_endpoint action=restore phase=ipc_completed terminal_result=failed error_domain=platform error_code=restore_request_failed reason=platform_rejected retryable=true".to_owned(),
+                    );
                     eprintln!("恢复已保存的音频端点失败：{error}");
                 }
             }
@@ -729,8 +922,18 @@ pub fn run() {
             }
 
             match settings.load_voice_hold_hotkey() {
-                Ok(hotkey) => platform.set_voice_hold_hotkey(hotkey),
+                Ok(hotkey) => {
+                    sayall_windows::gatt_note(format!(
+                        "shortcut_settings feature=voice_hold action=load phase=completed terminal_result=passed enabled={} key_count={}",
+                        hotkey.is_some(),
+                        hotkey.as_ref().map(|chord| chord.keys.len()).unwrap_or(0)
+                    ));
+                    platform.set_voice_hold_hotkey(hotkey)
+                }
                 Err(error) => {
+                    sayall_windows::gatt_note(
+                        "shortcut_settings feature=voice_hold action=load phase=completed terminal_result=failed error_domain=settings error_code=parse_or_read_failed reason=disabled_fallback retryable=true".to_owned(),
+                    );
                     eprintln!("{error}");
                     platform.set_voice_hold_hotkey(None);
                 }
@@ -751,6 +954,9 @@ pub fn run() {
                 settings,
                 pending_update: std::sync::Mutex::new(None),
             });
+            sayall_windows::gatt_note(
+                "app_lifecycle event=tauri_setup phase=completed terminal_result=passed window_created=true state_managed=true".to_owned(),
+            );
             Ok(())
         });
 
@@ -797,6 +1003,7 @@ pub fn run() {
         set_app_update_preferences,
         check_app_update,
         install_app_update,
+        report_frontend_event,
         run_runtime_simulation_voice_session,
         complete_runtime_simulation_smoke
     ]);
@@ -830,10 +1037,17 @@ pub fn run() {
         get_app_update_preferences,
         set_app_update_preferences,
         check_app_update,
-        install_app_update
+        install_app_update,
+        report_frontend_event
     ]);
 
-    builder
-        .run(tauri::generate_context!())
-        .expect("failed to run SayAll Windows app");
+    if let Err(_) = builder.run(tauri::generate_context!()) {
+        sayall_windows::gatt_note(
+            "app_lifecycle event=event_loop phase=completed terminal_result=failed error_domain=tauri error_code=run_failed reason=event_loop_failed retryable=false".to_owned(),
+        );
+        panic!("failed to run SayAll Windows app");
+    }
+    sayall_windows::gatt_note(
+        "app_lifecycle event=process_exit phase=completed terminal_result=passed".to_owned(),
+    );
 }

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -37,7 +37,7 @@ const PROGRESS_EVENT: &str = "app-update-progress";
 /// "已经是最新版本"，不让用户看到失败感文案；真实原因只写诊断日志。
 /// 已知代价：正式 Release 若漏挂 latest.json 资产，用户也会看到"已经是
 /// 最新版本"——由发布流程（windows-release.yml：缺 latest.json/.sig 即
-/// fail-fast 拒绝建 Release）与诊断日志（check.fail error=...）兜底。
+/// fail-fast 拒绝建 Release）与诊断日志（稳定 error_domain/error_code）兜底。
 fn release_not_found_counts_as_up_to_date(error: &UpdaterError) -> bool {
     matches!(error, UpdaterError::ReleaseNotFound)
 }
@@ -188,11 +188,9 @@ async fn resolve_update_endpoint(include_prereleases: bool) -> Result<UpdateEndp
             .trim()
             .trim_matches('"')
             .to_owned();
-        note(format!("check.endpoint_override url={endpoint}"));
-        let url = endpoint.parse().map_err(|error| {
-            note(format!(
-                "check.fail stage=endpoint_override_parse error={error:?}"
-            ));
+        note("check.endpoint_override configured=true".to_owned());
+        let url = endpoint.parse().map_err(|_error| {
+            note("check.fail stage=endpoint_override_parse error_domain=url error_code=parse_failed reason=invalid_override retryable=false".to_owned());
             "更新配置异常，请联系开发者".to_owned()
         })?;
         return Ok(UpdateEndpoint::Runtime(url));
@@ -216,10 +214,8 @@ async fn resolve_update_endpoint(include_prereleases: bool) -> Result<UpdateEndp
         .timeout(CHECK_TIMEOUT)
         .user_agent("SayAll-Windows-Updater")
         .build()
-        .map_err(|error| {
-            note(format!(
-                "check.fail channel=preview stage=client_build error={error:?}"
-            ));
+        .map_err(|_error| {
+            note("check.fail channel=preview stage=client_build error_domain=http error_code=client_build_failed reason=tls_or_client_configuration retryable=true".to_owned());
             "预览版更新暂时不可用，请稍后重试".to_owned()
         })?;
     let response = client
@@ -228,31 +224,29 @@ async fn resolve_update_endpoint(include_prereleases: bool) -> Result<UpdateEndp
         .send()
         .await
         .and_then(reqwest::Response::error_for_status)
-        .map_err(|error| {
+        .map_err(|_error| {
             note(format!(
-                "check.fail channel=preview stage=releases_request error={error:?} took_ms={}",
+                "check.fail channel=preview stage=releases_request error_domain=http error_code=request_failed reason=network_or_status retryable=true took_ms={}",
                 elapsed_ms(started)
             ));
             "网络连接失败，请稍后重试".to_owned()
         })?;
-    let feed_xml = response.text().await.map_err(|error| {
+    let feed_xml = response.text().await.map_err(|_error| {
         note(format!(
-            "check.fail channel=preview stage=releases_read error={error:?} took_ms={}",
+            "check.fail channel=preview stage=releases_read error_domain=http error_code=body_read_failed reason=response_body_unavailable retryable=true took_ms={}",
             elapsed_ms(started)
         ));
         "预览版更新暂时不可用，请稍后重试".to_owned()
     })?;
-    let feed = quick_xml::de::from_str::<ReleasesFeed>(&feed_xml).map_err(|error| {
+    let feed = quick_xml::de::from_str::<ReleasesFeed>(&feed_xml).map_err(|_error| {
         note(format!(
-            "check.fail channel=preview stage=releases_parse error={error:?} took_ms={}",
+            "check.fail channel=preview stage=releases_parse error_domain=xml error_code=parse_failed reason=feed_invalid retryable=true took_ms={}",
             elapsed_ms(started)
         ));
         "预览版更新暂时不可用，请稍后重试".to_owned()
     })?;
-    let preview = preview_manifest_endpoint(&feed).map_err(|error| {
-        note(format!(
-            "check.fail channel=preview stage=manifest_url error={error:?}"
-        ));
+    let preview = preview_manifest_endpoint(&feed).map_err(|_error| {
+        note("check.fail channel=preview stage=manifest_url error_domain=url error_code=parse_failed reason=manifest_url_invalid retryable=true".to_owned());
         "预览版更新暂时不可用，请稍后重试".to_owned()
     })?;
     match preview {
@@ -295,15 +289,13 @@ fn build_updater(
         ));
     });
     if let Some(endpoint) = runtime_endpoint {
-        builder = builder.endpoints(vec![endpoint]).map_err(|error| {
-            note(format!(
-                "check.fail stage=runtime_endpoint_reject error={error:?}"
-            ));
+        builder = builder.endpoints(vec![endpoint]).map_err(|_error| {
+            note("check.fail stage=runtime_endpoint_reject error_domain=updater error_code=endpoint_rejected reason=runtime_endpoint_invalid retryable=false".to_owned());
             "更新配置异常，请联系开发者".to_owned()
         })?;
     }
-    builder.build().map_err(|error| {
-        note(format!("check.fail stage=build error={error:?}"));
+    builder.build().map_err(|_error| {
+        note("check.fail stage=build error_domain=updater error_code=build_failed reason=updater_configuration_invalid retryable=true".to_owned());
         "更新功能暂时不可用，请稍后重试".to_owned()
     })
 }
@@ -317,8 +309,8 @@ pub async fn check_app_update(
     let include_prereleases = state
         .settings
         .load()
-        .map_err(|error| {
-            note(format!("check.fail stage=preference_load error={error:?}"));
+        .map_err(|_error| {
+            note("check.fail stage=preference_load error_domain=settings error_code=load_failed reason=update_preference_unavailable retryable=true".to_owned());
             "读取更新设置失败，请稍后重试".to_owned()
         })?
         .check_prerelease_updates;
@@ -385,9 +377,8 @@ pub async fn check_app_update(
             })
         }
         Err(error) => {
-            // 日志保留插件原始错误（诊断用）；用户可见文案去技术化。
             note(format!(
-                "check.fail error={error:?} took_ms={}",
+                "check.fail error_domain=updater error_code=check_failed reason=manifest_or_network_failure retryable=true took_ms={}",
                 elapsed_ms(started)
             ));
             // 取不到清单（404 类）→ 呈现为"已经是最新版本"（2026-09-06 终裁）。
@@ -416,8 +407,8 @@ pub fn get_app_update_preferences(
     let include_prereleases = state
         .settings
         .load()
-        .map_err(|error| {
-            note(format!("preference.load result=failed error={error:?}"));
+        .map_err(|_error| {
+            note("preference.load result=failed error_domain=settings error_code=load_failed reason=preference_unavailable retryable=true".to_owned());
             "读取预览版更新设置失败，请稍后重试".to_owned()
         })?
         .check_prerelease_updates;
@@ -439,15 +430,15 @@ pub async fn set_app_update_preferences(
         settings.save_check_prerelease_updates(include_prereleases)
     })
     .await
-    .map_err(|error| {
+    .map_err(|_error| {
         note(format!(
-            "preference.save result=task_failed include_prereleases={include_prereleases} error={error:?}"
+            "preference.save result=task_failed include_prereleases={include_prereleases} error_domain=runtime error_code=task_failed reason=worker_unavailable retryable=true"
         ));
         "保存预览版更新设置失败，请稍后重试".to_owned()
     })?;
-    save_result.map_err(|error| {
+    save_result.map_err(|_error| {
         note(format!(
-            "preference.save result=write_failed include_prereleases={include_prereleases} error={error:?}"
+            "preference.save result=write_failed include_prereleases={include_prereleases} error_domain=settings error_code=write_failed reason=persistence_unavailable retryable=true"
         ));
         "保存预览版更新设置失败，请稍后重试".to_owned()
     })?;
@@ -465,8 +456,8 @@ pub async fn install_app_update(app: AppHandle, state: State<'_, AppState>) -> R
     let mut update = state
         .pending_update
         .lock()
-        .map_err(|error| {
-            note(format!("install.fail stage=state_lock error={error:?}"));
+        .map_err(|_error| {
+            note("install.fail stage=state_lock error_domain=state error_code=lock_failed reason=pending_update_unavailable retryable=true".to_owned());
             "更新状态异常，请重启应用后重试".to_owned()
         })?
         .take()
@@ -535,9 +526,8 @@ pub async fn install_app_update(app: AppHandle, state: State<'_, AppState>) -> R
                 .lock()
                 .map(|progress| progress.downloaded)
                 .unwrap_or(0);
-            // 日志保留插件原始错误（诊断用）；用户可见文案去技术化。
             note(format!(
-                "install.fail downloaded={downloaded} error={error:?} took_ms={}",
+                "install.fail downloaded={downloaded} error_domain=updater error_code=install_failed reason=download_or_install_failure retryable=true took_ms={}",
                 elapsed_ms(started)
             ));
             Err(install_error_message(&error))
@@ -704,12 +694,15 @@ mod tests {
         // 本测试二进制内无其他代码先初始化 gatt_sink（OnceLock 首次调用生效）。
         // SAFETY: 测试进程内单线程操作该环境变量，其余测试不读取它。
         unsafe { std::env::set_var("SAYALL_GATT_LOG", &path) };
-        note("check.fail stage=endpoint_override_parse error=probe".to_owned());
+        note("check.fail stage=endpoint_override_parse error_domain=url error_code=parse_failed reason=invalid_override retryable=false".to_owned());
         let contents = std::fs::read_to_string(&path).unwrap_or_default();
         unsafe { std::env::remove_var("SAYALL_GATT_LOG") };
         let _ = std::fs::remove_file(&path);
         assert!(
-            contents.contains("note=updater.check.fail stage=endpoint_override_parse"),
+            contents.contains("updater.check.fail stage=endpoint_override_parse")
+                && contents.contains("error_code=parse_failed")
+                && contents.starts_with("20")
+                && !contents.contains("note="),
             "updater 功能点日志未落盘：{contents}"
         );
     }

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, onUnmounted, ref } from "vue";
 import Sidebar from "./components/Sidebar.vue";
 import { getRuntimeSnapshot, type RuntimeSnapshot } from "./lib/bridge";
+import { reportFrontendEvent } from "./lib/frontend-diagnostics";
 import { useAppUpdate } from "./lib/app-update";
 import type { PageId } from "./navigation";
 import AboutPage from "./pages/AboutPage.vue";
@@ -15,6 +16,7 @@ const loadError = ref("");
 const { bannerVisible, info: updateInfo, dismissBanner, runStartupSilentCheck } = useAppUpdate();
 let runtimePollTimer: ReturnType<typeof setInterval> | undefined;
 let updateCheckTimer: ReturnType<typeof setTimeout> | undefined;
+let initialRuntimeReported = false;
 
 const activeComponent = computed(() => ({
   buttons: ButtonsPage,
@@ -37,8 +39,26 @@ onMounted(async () => {
     try {
       runtime.value = await getRuntimeSnapshot();
       loadError.value = "";
+      if (!initialRuntimeReported) {
+        reportFrontendEvent({
+          event: "runtime_snapshot",
+          phase: "completed",
+          result: "passed",
+          reason: "initial_ipc_ready",
+        });
+        initialRuntimeReported = true;
+      }
     } catch (error) {
       loadError.value = error instanceof Error ? error.message : String(error);
+      if (!initialRuntimeReported) {
+        reportFrontendEvent({
+          event: "runtime_snapshot",
+          phase: "completed",
+          result: "failed",
+          reason: "initial_ipc_failed",
+        });
+        initialRuntimeReported = true;
+      }
     }
   };
   await refreshRuntime();

--- a/src/lib/frontend-diagnostics.ts
+++ b/src/lib/frontend-diagnostics.ts
@@ -1,0 +1,50 @@
+import { invoke } from "@tauri-apps/api/core";
+import { isTauriRuntime } from "./bridge";
+
+const bootStarted = performance.now();
+
+export interface FrontendDiagnosticEvent {
+  event: string;
+  phase: string;
+  result: "passed" | "failed" | "unknown";
+  reason: string;
+  elapsedMs?: number;
+}
+
+export function reportFrontendEvent(event: FrontendDiagnosticEvent): void {
+  if (!isTauriRuntime()) return;
+  void invoke("report_frontend_event", {
+    report: {
+      ...event,
+      elapsedMs: event.elapsedMs ?? Math.max(0, Math.round(performance.now() - bootStarted)),
+    },
+  }).catch(() => {
+    // 日志 IPC 本身失败时不能递归上报；开发控制台保留一个无用户内容的信号。
+    console.error("feature=frontend_diagnostics result=failed reason=ipc_unavailable");
+  });
+}
+
+export function installFrontendDiagnostics(): void {
+  reportFrontendEvent({
+    event: "script_evaluation",
+    phase: "started",
+    result: "passed",
+    reason: "entry_module_loaded",
+  });
+  window.addEventListener("error", () => {
+    reportFrontendEvent({
+      event: "window_error",
+      phase: "completed",
+      result: "failed",
+      reason: "uncaught_javascript_error",
+    });
+  }, true);
+  window.addEventListener("unhandledrejection", () => {
+    reportFrontendEvent({
+      event: "unhandled_rejection",
+      phase: "completed",
+      result: "failed",
+      reason: "uncaught_async_error",
+    });
+  });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,11 +2,39 @@ import { createApp } from "vue";
 import App from "./App.vue";
 import { isTauriRuntime } from "./lib/bridge";
 import { initializeTheme } from "./lib/theme";
+import { installFrontendDiagnostics, reportFrontendEvent } from "./lib/frontend-diagnostics";
 import "./styles.css";
 
+installFrontendDiagnostics();
 // 初始化调用在 Vue 挂载前同步应用首帧主题；异步读取设置不阻塞主界面。
 void initializeTheme();
-createApp(App).mount("#app");
+try {
+  const app = createApp(App);
+  app.config.errorHandler = () => {
+    reportFrontendEvent({
+      event: "vue_runtime_error",
+      phase: "completed",
+      result: "failed",
+      reason: "component_render_or_lifecycle_failed",
+    });
+  };
+  app.mount("#app");
+  reportFrontendEvent({
+    event: "vue_mount",
+    phase: "completed",
+    result: "passed",
+    reason: "root_component_mounted",
+  });
+} catch {
+  reportFrontendEvent({
+    event: "vue_mount",
+    phase: "completed",
+    result: "failed",
+    reason: "root_component_mount_failed",
+  });
+  const root = document.querySelector<HTMLElement>("#app");
+  if (root) root.textContent = "无线麦启动失败。请将诊断日志发送给技术支持。";
+}
 
 // 桌面应用内禁用 WebView 默认右键菜单（浏览器预览保留原生菜单，便于调试）。
 if (isTauriRuntime()) {


### PR DESCRIPTION
## Summary

- persist production diagnostics by default under LocalAppData with UTC/build/source metadata
- cover app/WebView/Vue startup, audio endpoint state and Bluetooth classification, WASAPI session lifecycle, and shortcut settings
- remove raw audio packets, endpoint identity, custom paths, foreground app identity, and raw updater errors from logs
- document collection and white-screen phase triage

## Verification

- passed: scripts/ci-preflight.ps1 -Full (7/7)
- passed after rebase: scripts/ci-preflight.ps1 (6/6)
- passed: production default log integration test, including metadata and ISO timestamp
- passed: frontend tests (52)
- passed: Rust workspace tests (123 passed; hardware/network-only tests ignored)
- deferred: real Bluetooth headset failure reproduction
- deferred: installed-user white-screen field reproduction
- deferred: RC001/RC003 hardware verification (logging-only change; no claim of new hardware pass)
