### PR TITLE
release: prepare 0.2.3 preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3103,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "sayall-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -3112,7 +3112,7 @@ dependencies = [
 
 [[package]]
 name = "sayall-windows"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "futures",
  "sayall-core",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "sayall-windows-app"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "quick-xml",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "GPL-3.0-only"
 repository = "https://github.com/GetSayAll/remote-mic-app-windows"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sayall-windows",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.15.0",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "无线麦 SayAll",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "identifier": "app.getsayall.remote-mic.windows",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary
- bump workspace, frontend, and Tauri package versions to 0.2.3
- keep the release commit limited to version metadata

## Verification
- scripts/ci-preflight.ps1 (6/6 passed)
- release workflow will build and verify the signed updater assets from the merged main commit

## Validation boundary
- automated Windows CI covers WebView/IPC runtime simulation and installer lifecycle
- RC001/RC003 and affected Bluetooth-headset hardware regression remain deferred until physical devices are available