### PR TITLE
fix: prevent startup deadlock and RC003 WeType hold recovery

### DIFF
--- a/Bugs/2026-09-09-audio-interrupt-deadlock.md
+++ b/Bugs/2026-09-09-audio-interrupt-deadlock.md
@@ -1,0 +1,13 @@
+# Audio interrupt freezes the application after launch
+
+- Discovered: 2026-09-09.
+- Status: fixed; Windows worker regression and application startup acceptance passed.
+- Scope: Windows v0.2.3, introduced by production diagnostics in df63e5e.
+- Trigger: launch with a saved remote. Restore schedules a BLE connection, whose cleanup first interrupts audio.
+- Expected: audio cleanup replies and the initial runtime snapshot renders.
+- Evidence: five existing launch traces stopped after Vue mount without initial IPC completion. A fresh launch also reported Responding=False. The real audio-worker regression timed out after two seconds on the original implementation and completed immediately after the fix.
+- Cause: AudioMessage::Interrupt passed two lock(&state) guards to one format! expression. Rust retained the first temporary guard until the statement ended, so acquiring the same non-reentrant mutex again blocked forever. UI snapshot polling then blocked on that mutex too. The log call itself was never reached.
+- Fix: read generation and submitted_samples under one short lock, then format and write the log after releasing it.
+- Validation: interrupt_worker_replies_and_keeps_snapshot_readable failed on the original code; passed after the patch. The test exercises two consecutive interruptions, readable shared state, and worker shutdown on Windows without opening an audio device.
+- Application acceptance: the release executable started on the affected host at 02:53:11 UTC. Audio interruption completed in 0 ms; frontend initial_ipc_ready completed at 02:53:12.761 UTC, 183 ms after script initialization. Windows reported Responding=True, the UI exposed its controls, and the RC003 completed ATVV capability negotiation.
+- Privacy: no device identifiers, personal paths, audio, credentials, or third-party private data included.

--- a/Bugs/2026-09-09-wetype-history-false-recovery.md
+++ b/Bugs/2026-09-09-wetype-history-false-recovery.md
@@ -1,0 +1,14 @@
+# WeType history can interrupt a continuously held voice key
+
+- Discovered: 2026-09-09.
+- Status: fixed in source; RC003 and WeType end-to-end acceptance pending.
+- Scope: Windows v0.2.2 and v0.2.3, RC003 with WeType.
+- Symptom: dictation starts, stops after roughly one second, then restarts and stops repeatedly while the remote voice key remains held.
+- Trigger: multiple historical WeType executable entries in Windows microphone ConsentStore.
+- Expected: one chord DOWN/UP pair for one physical voice hold, without restarting an already active recording.
+- Evidence: the affected host has seven WeType history entries. The original enumeration returns the first, version 2.1.0.36 last used in July; the running version is 2.1.3.18 and the seventh entry updates in September. The original 700 ms detector reads the old entry, invokes TSF profile cycling, and schedules release/repress after 2, 3, and 5 seconds. Historical v0.2.2 session logs were unavailable, so the exact prior on-screen sequence remains user-reported.
+- Cause: first-match registry enumeration is not current-version selection. The detector also captured its baseline after injection and treated an unavailable observation as failure. A queued stale retry removed held_hotkey before checking its session epoch.
+- Fix: aggregate all matching entries, recognize active microphone use via LastUsedTimeStop, capture the baseline before injection, and suppress recovery for unknown observations. Recheck after the recovery delay and before releasing a chord. Validate session identity before consuming the held chord, preserving cleanup ownership if release fails.
+- Timing: existing 700 ms checks, retry delays, chord spacing, and ATVV extension intervals are unchanged.
+- Validation: five regression cases cover version history/order, an already active baseline, newly completed recording, genuinely unchanged inactive history, and unavailable/regressed observations. A separate ignored Windows test reads only aggregate observation availability and counts.
+- Privacy: registry reads use the public Windows microphone access history. No WeType private configuration is read or written; diagnostics contain no paths, raw timestamps, voice data, or input text.

--- a/Bugs/2026-09-09-wetype-history-false-recovery.md
+++ b/Bugs/2026-09-09-wetype-history-false-recovery.md
@@ -1,7 +1,7 @@
 # WeType history can interrupt a continuously held voice key
 
 - Discovered: 2026-09-09.
-- Status: fixed in source; RC003 and WeType end-to-end acceptance pending.
+- Status: fixed; RC003 and WeType continuous-hold acceptance passed on the affected Windows host.
 - Scope: Windows v0.2.2 and v0.2.3, RC003 with WeType.
 - Symptom: dictation starts, stops after roughly one second, then restarts and stops repeatedly while the remote voice key remains held.
 - Trigger: multiple historical WeType executable entries in Windows microphone ConsentStore.
@@ -11,4 +11,5 @@
 - Fix: aggregate all matching entries, recognize active microphone use via LastUsedTimeStop, capture the baseline before injection, and suppress recovery for unknown observations. Recheck after the recovery delay and before releasing a chord. Validate session identity before consuming the held chord, preserving cleanup ownership if release fails.
 - Timing: existing 700 ms checks, retry delays, chord spacing, and ATVV extension intervals are unchanged.
 - Validation: five regression cases cover version history/order, an already active baseline, newly completed recording, genuinely unchanged inactive history, and unavailable/regressed observations. A separate ignored Windows test reads only aggregate observation availability and counts.
+- Hardware acceptance: the user confirmed uninterrupted dictation ending only on physical release. Two captured holds lasted about 13 seconds each, with WeType response detected on attempt 0, periodic MIC_EXTEND commands, and one successful chord release followed by successful audio drain. The later hold started after almost four minutes idle. RC001 hardware and installer upgrade acceptance remain deferred for this patch.
 - Privacy: registry reads use the public Windows microphone access history. No WeType private configuration is read or written; diagnostics contain no paths, raw timestamps, voice data, or input text.

--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,7 @@
 
 ## Windows RC001 / RC003
 
+- [x] Fix v0.2.3 startup deadlock in audio interrupt diagnostics: single-lock snapshot extraction; original worker regression failed, repaired worker and affected Windows host startup passed on 2026-09-09. See Bugs/2026-09-09-audio-interrupt-deadlock.md.
 - [x] 建立独立 Rust + Tauri 2 + Vue 3 工程结构。
 - [x] 建立 Mac 原版风格设置界面骨架。
 - [x] 建立 ATVV、ADPCM 和语音会话纯 Rust 核心。

--- a/crates/sayall-windows/src/audio.rs
+++ b/crates/sayall-windows/src/audio.rs
@@ -370,13 +370,16 @@ fn worker_loop(receiver: Receiver<AudioMessage>, state: Arc<Mutex<AudioSnapshot>
                     pending_drain = Some((generation, reply));
                 }
                 AudioMessage::Interrupt { reply } => {
-                    let generation = lock(&state).generation;
+                    let (generation, submitted_samples) = {
+                        let snapshot = lock(&state);
+                        (snapshot.generation, snapshot.submitted_samples)
+                    };
                     let started = Instant::now();
                     crate::ble::gatt_note(format!(
                         "audio_session generation={} action=interrupt phase=requested queued_samples={} submitted_samples={}",
-                        lock(&state).generation,
+                        generation,
                         queue.len(),
-                        lock(&state).submitted_samples
+                        submitted_samples
                     ));
                     if let Some((_, pending_reply)) = pending_drain.take() {
                         let _ = pending_reply.send(Err(PlatformError::AudioSessionInterrupted));
@@ -1246,6 +1249,26 @@ mod tests {
             generation,
             ..AudioSnapshot::default()
         }))
+    }
+
+    #[test]
+    fn interrupt_worker_replies_and_keeps_snapshot_readable() {
+        let (sender, receiver) = mpsc::sync_channel(MESSAGE_QUEUE_CAPACITY);
+        let state = Arc::new(Mutex::new(AudioSnapshot::default()));
+        let worker_state = Arc::clone(&state);
+        let worker = thread::spawn(move || worker_loop(receiver, worker_state));
+        for _ in 0..2 {
+            let (reply, response) = mpsc::channel();
+            sender.send(AudioMessage::Interrupt { reply }).unwrap();
+            let snapshot = response
+                .recv_timeout(Duration::from_secs(2))
+                .expect("audio interrupt deadlocked before replying")
+                .unwrap();
+            assert_eq!(snapshot.phase, AudioPhase::Unconfigured);
+            assert!(state.try_lock().is_ok(), "audio snapshot remained locked");
+        }
+        sender.send(AudioMessage::Shutdown).unwrap();
+        worker.join().unwrap();
     }
 
     #[test]

--- a/crates/sayall-windows/src/ble.rs
+++ b/crates/sayall-windows/src/ble.rs
@@ -1,3 +1,4 @@
+use crate::wetype_revive::{response_since, wetype_mic_observation, MicObservation, MicResponse};
 use crate::{
     audio::AudioRuntime, power::PowerNotifications, reconnect::ReconnectBackoff,
     remote_model_from_model_number, remote_model_from_name, send_input::KeyChord,
@@ -178,6 +179,7 @@ pub(crate) enum WorkerMessage {
     RetryVoiceChord {
         attempt: u32,
         epoch: u64,
+        baseline: Option<MicObservation>,
     },
     Control {
         connection_generation: u64,
@@ -526,40 +528,59 @@ fn worker_loop(
                     // 撞上配置切换重绑窗口的自伤风险，已移除）。
                 }
             }
-            WorkerMessage::RetryVoiceChord { attempt, epoch } => {
+            WorkerMessage::RetryVoiceChord {
+                attempt,
+                epoch,
+                baseline,
+            } => {
                 // 微信输入法热键休眠的自动重试（同一次按住内完成）：
                 // 释放旧和弦边沿 → 重注入。在工作线程内串行执行，与
                 // StreamStopped/中止路径无竞态；仅在会话仍在流式且纪元
                 // 未变（未被新会话替换）时执行。
+                // Validate before taking ownership: a stale retry must never
+                // discard the chord needed to release the current session.
+                if pipeline.state() != VoiceSessionState::Streaming
+                    || voice_session_epoch.load(Ordering::SeqCst) != epoch
+                {
+                    gatt_note(format!("chord_retry skipped reason=stale epoch={epoch}"));
+                    continue;
+                }
+                let retry_baseline = wetype_mic_observation();
+                if response_since(baseline, retry_baseline) != MicResponse::NotObserved {
+                    gatt_note(format!(
+                        "chord_retry skipped reason=mic_active_or_unknown epoch={epoch}"
+                    ));
+                    continue;
+                }
                 let chord_configured = lock(&voice_hold_hotkey).clone();
-                let old_held = held_hotkey.take();
-                if let (Some(chord), Some(old)) = (chord_configured, old_held) {
-                    if pipeline.state() == VoiceSessionState::Streaming
-                        && voice_session_epoch.load(Ordering::SeqCst) == epoch
-                    {
-                        let _ = send_input.release(&old);
-                        match send_input.press(&chord) {
-                            Ok(_) => {
-                                gatt_note(format!(
-                                    "chord_retry result=ok attempt={attempt} epoch={epoch}"
-                                ));
-                                held_hotkey = Some(chord);
-                                spawn_wetype_check(
-                                    &state,
-                                    sender.clone(),
-                                    attempt,
-                                    epoch,
-                                    &voice_session_epoch,
-                                );
-                            }
-                            Err(_) => {
-                                gatt_note(format!(
+                if let (Some(chord), Some(old)) = (chord_configured, held_hotkey.as_ref()) {
+                    if send_input.release(old).is_err() {
+                        gatt_note(format!(
+                            "chord_retry result=err reason=release_failed epoch={epoch}"
+                        ));
+                        continue;
+                    }
+                    held_hotkey = None;
+                    match send_input.press(&chord) {
+                        Ok(_) => {
+                            gatt_note(format!(
+                                "chord_retry result=ok attempt={attempt} epoch={epoch}"
+                            ));
+                            held_hotkey = Some(chord);
+                            spawn_wetype_check(
+                                &state,
+                                sender.clone(),
+                                attempt,
+                                epoch,
+                                &voice_session_epoch,
+                                retry_baseline,
+                            );
+                        }
+                        Err(_) => {
+                            gatt_note(format!(
                                     "chord_retry result=err attempt={attempt} epoch={epoch} error_domain=send_input error_code=retry_failed reason=injection_failed retryable=true"
                                 ));
-                            }
                         }
-                    } else {
-                        gatt_note(format!("chord_retry skipped reason=stale epoch={epoch}"));
                     }
                 } else {
                     gatt_note("chord_retry skipped reason=no_chord".to_owned());
@@ -1025,6 +1046,7 @@ fn handle_control(
             // 按住说话快捷键（参考 ZSTDJan/Voice_VibeCoding）：先注入快捷键
             // DOWN，再开始音频会话；注入失败直接中止本次会话并统一释放。
             if let Some(chord) = lock(voice_hold_hotkey).clone() {
+                let mic_baseline = wetype_mic_observation();
                 // 会话级激活微信输入法：其语音热键只在自身为当前会话活动
                 // 输入法时生效（2026-09-05 持锁实验，evidence/p）；激活后零
                 // 延迟注入 3/3 触发，不增加按键延迟。失败仅记录提示，按原
@@ -1058,7 +1080,14 @@ fn handle_control(
                 // WeType 热键休眠检测与自动恢复（见 spawn_wetype_check）。
                 // 纪元在 StreamStarted 顶部已递增并捕获（见上），连同引用
                 // 传入，防旧阶梯跨会话误伤新会话的和弦。
-                spawn_wetype_check(state, sender.clone(), 0, epoch, voice_session_epoch);
+                spawn_wetype_check(
+                    state,
+                    sender.clone(),
+                    0,
+                    epoch,
+                    voice_session_epoch,
+                    mic_baseline,
+                );
             } else {
                 // 功能点日志：会话开始但未配置按住说话快捷键（无注入环节）。
                 gatt_note(format!(
@@ -1701,12 +1730,13 @@ fn spawn_wetype_check(
     attempt: u32,
     epoch: u64,
     epoch_ref: &Arc<AtomicU64>,
+    baseline: Option<MicObservation>,
 ) {
     let state = Arc::clone(state);
     let epoch_ref = Arc::clone(epoch_ref);
-    let baseline = crate::wetype_revive::wetype_mic_start();
     gatt_note(format!(
-        "wetype_check armed attempt={attempt} epoch={epoch} baseline={baseline:?}"
+        "wetype_check armed attempt={attempt} epoch={epoch} baseline_available={}",
+        baseline.is_some()
     ));
     std::thread::Builder::new()
         .name("sayall-wetype-check".to_owned())
@@ -1729,17 +1759,20 @@ fn spawn_wetype_check(
                 });
                 return;
             }
-            let now = crate::wetype_revive::wetype_mic_start();
-            let reacted = match (baseline, now) {
-                (Some(base), Some(current)) => current > base,
-                (None, Some(_)) => true,
-                _ => false,
-            };
-            if reacted {
-                gatt_note(format!(
-                    "wetype_check reacted=true attempt={attempt} epoch={epoch}"
-                ));
-                return;
+            match response_since(baseline, wetype_mic_observation()) {
+                MicResponse::Observed => {
+                    gatt_note(format!(
+                        "wetype_check reacted=true attempt={attempt} epoch={epoch}"
+                    ));
+                    return;
+                }
+                MicResponse::Unknown => {
+                    gatt_note(format!(
+                        "wetype_check skipped reason=observation_unavailable attempt={attempt} epoch={epoch}"
+                    ));
+                    return;
+                }
+                MicResponse::NotObserved => {}
             }
             if attempt >= WETYPE_RETRY_MAX_ATTEMPT {
                 // 最后一轮仍未响应：放弃自动恢复，提示人工（唯一兜底）。
@@ -1757,7 +1790,8 @@ fn spawn_wetype_check(
             ));
             let revive = crate::ime::cycle_wetype_profile();
             gatt_note(format!(
-                "wetype_revive result={revive:?} attempt={attempt} epoch={epoch}"
+                "wetype_revive result={} attempt={attempt} epoch={epoch}",
+                if revive.is_ok() { "ok" } else { "err" }
             ));
             std::thread::sleep(std::time::Duration::from_millis(
                 WETYPE_RETRY_SETTLE_MS[attempt as usize],
@@ -1779,10 +1813,17 @@ fn spawn_wetype_check(
                 });
                 return;
             }
+            if response_since(baseline, wetype_mic_observation()) != MicResponse::NotObserved {
+                gatt_note(format!(
+                    "wetype_check skipped_retry reason=mic_active_or_unknown attempt={attempt} epoch={epoch}"
+                ));
+                return;
+            }
             let next_attempt = attempt + 1;
             let _ = sender.send(WorkerMessage::RetryVoiceChord {
                 attempt: next_attempt,
                 epoch,
+                baseline,
             });
         })
         .ok();

--- a/crates/sayall-windows/src/wetype_revive.rs
+++ b/crates/sayall-windows/src/wetype_revive.rs
@@ -1,30 +1,80 @@
-//! ConsentStore 微信输入法（WeType）开麦判据读取。
-//!
-//! 用途（2026-09-05 WeType 热键休眠调查）：WeType 内部状态不可观测，
-//! ConsentStore 的 LastUsedTimeStart 时间戳是"微信输入法真的响应并打开了
-//! 麦克风"的唯一公开判据——与整晚持锁实验的 ground truth 相同。
-//! 供 ble.rs 的 wetype_check（热键休眠检测与自动恢复）使用。
-//!
-//! 历史注记：曾实现"对 WeType 进程解除后台节流"作为唤醒手段，真机实证
-//! 跨进程 SetProcessInformation(ProcessPowerThrottling) 返回 E_INVALIDARG
-//! （不支持作用于其他进程），方案已由 ime.rs 的 TSF 配置切换唤醒取代。
+//! Observe WeType microphone use through the public Windows ConsentStore.
+//! Updates leave historical executable entries behind; enumeration order is
+//! unrelated to the version that is currently recording.
 
+use windows::Win32::Foundation::ERROR_NO_MORE_ITEMS;
 use windows::Win32::System::Registry::{
     RegCloseKey, RegEnumKeyExW, RegOpenKeyExW, RegQueryValueExW, HKEY, HKEY_CURRENT_USER, KEY_READ,
-    REG_VALUE_TYPE,
+    REG_QWORD, REG_VALUE_TYPE,
 };
 
-/// ConsentStore microphone\NonPackaged 根键。
 const CONSENT_NONPACKAGED: &str =
     "Software\\Microsoft\\Windows\\CurrentVersion\\CapabilityAccessManager\\ConsentStore\\microphone\\NonPackaged";
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct MicObservation {
+    latest_start: u64,
+    active: bool,
+    entries: usize,
+}
+
+impl MicObservation {
+    fn record(&mut self, start: u64, stop: u64) {
+        self.latest_start = self.latest_start.max(start);
+        self.active |= start > 0 && stop == 0;
+        self.entries += 1;
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MicResponse {
+    Observed,
+    NotObserved,
+    Unknown,
+}
+
+pub(crate) fn response_since(
+    baseline: Option<MicObservation>,
+    current: Option<MicObservation>,
+) -> MicResponse {
+    match (baseline, current) {
+        (_, Some(current)) if current.active => MicResponse::Observed,
+        (Some(base), Some(current)) if current.latest_start > base.latest_start => {
+            MicResponse::Observed
+        }
+        (Some(base), Some(current))
+            if current.entries >= base.entries && current.latest_start == base.latest_start =>
+        {
+            MicResponse::NotObserved
+        }
+        _ => MicResponse::Unknown,
+    }
+}
 
 fn wide(text: &str) -> Vec<u16> {
     text.encode_utf16().chain([0]).collect()
 }
 
-/// 读取 WeType 的最近开麦时间戳（原始 FILETIME，100ns 单位）。
-/// 未找到 WeType 条目或读取失败返回 None（调用方按"无法判定"处理）。
-pub fn wetype_mic_start() -> Option<u64> {
+fn read_qword(key: HKEY, name: &str) -> Option<u64> {
+    let value = wide(name);
+    let mut data = 0_u64;
+    let mut size = std::mem::size_of::<u64>() as u32;
+    let mut kind = REG_VALUE_TYPE::default();
+    let result = unsafe {
+        RegQueryValueExW(
+            key,
+            windows::core::PCWSTR(value.as_ptr()),
+            None,
+            Some(&mut kind),
+            Some((&mut data as *mut u64).cast()),
+            Some(&mut size),
+        )
+    };
+    (result.0 == 0 && kind == REG_QWORD && size == 8).then_some(data)
+}
+
+/// Missing or partially unreadable observations must not trigger recovery.
+pub(crate) fn wetype_mic_observation() -> Option<MicObservation> {
     let subkey = wide(CONSENT_NONPACKAGED);
     let mut root = HKEY::default();
     if unsafe {
@@ -40,11 +90,13 @@ pub fn wetype_mic_start() -> Option<u64> {
     {
         return None;
     }
-    let mut index: u32 = 0;
+    let mut index = 0;
+    let mut observation = MicObservation::default();
+    let mut complete = true;
     loop {
         let mut name = [0u16; 260];
         let mut len = name.len() as u32;
-        if unsafe {
+        let result = unsafe {
             RegEnumKeyExW(
                 root,
                 index,
@@ -55,14 +107,17 @@ pub fn wetype_mic_start() -> Option<u64> {
                 None,
                 None,
             )
+        };
+        if result == ERROR_NO_MORE_ITEMS {
+            break;
         }
-        .0 != 0
-        {
+        if result.0 != 0 {
+            complete = false;
             break;
         }
         index += 1;
-        let entry = String::from_utf16_lossy(&name[..len as usize]).to_lowercase();
-        if !entry.contains("wetype") {
+        let entry = String::from_utf16_lossy(&name[..len as usize]);
+        if !entry.to_ascii_lowercase().contains("wetype") {
             continue;
         }
         let mut key = HKEY::default();
@@ -78,34 +133,110 @@ pub fn wetype_mic_start() -> Option<u64> {
         }
         .0 != 0
         {
+            complete = false;
             continue;
         }
-        let value = wide("LastUsedTimeStart");
-        let mut data: u64 = 0;
-        let mut size = std::mem::size_of::<u64>() as u32;
-        let mut kind = REG_VALUE_TYPE::default();
-        let queried = unsafe {
-            RegQueryValueExW(
-                key,
-                windows::core::PCWSTR(value.as_ptr()),
-                None,
-                Some(&mut kind),
-                Some((&mut data as *mut u64).cast()),
-                Some(&mut size),
-            )
-        };
+        let start = read_qword(key, "LastUsedTimeStart");
+        let stop = read_qword(key, "LastUsedTimeStop");
         unsafe {
             let _ = RegCloseKey(key);
         }
-        if queried.0 == 0 {
-            unsafe {
-                let _ = RegCloseKey(root);
-            }
-            return Some(data);
+        match (start, stop) {
+            (Some(start), Some(stop)) => observation.record(start, stop),
+            _ => complete = false,
         }
     }
     unsafe {
         let _ = RegCloseKey(root);
     }
-    None
+    (complete && observation.entries > 0).then_some(observation)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[ignore = "requires installed WeType microphone history; read-only"]
+    fn live_consentstore_observation_is_readable() {
+        let observation = wetype_mic_observation().expect("WeType observation unavailable");
+        assert!(observation.entries > 0);
+        println!(
+            "wetype_observation entries={} active={}",
+            observation.entries, observation.active
+        );
+    }
+
+    fn stopped(start: u64) -> MicObservation {
+        let mut result = MicObservation::default();
+        result.record(start, start + 1);
+        result
+    }
+
+    #[test]
+    fn historical_versions_do_not_hide_current_recording() {
+        let mut baseline = MicObservation::default();
+        for start in [10, 20, 30, 40, 50, 60, 70] {
+            baseline.record(start, start + 1);
+        }
+        let mut current = MicObservation::default();
+        for start in [10, 20, 30, 40, 50, 60] {
+            current.record(start, start + 1);
+        }
+        current.record(80, 0);
+        assert_eq!(
+            response_since(Some(baseline), Some(current)),
+            MicResponse::Observed
+        );
+        let mut reversed = MicObservation::default();
+        reversed.record(80, 0);
+        for start in [60, 50, 40, 30, 20, 10] {
+            reversed.record(start, start + 1);
+        }
+        assert_eq!(current, reversed);
+    }
+
+    #[test]
+    fn active_recording_is_not_retried_even_if_baseline_already_contains_start() {
+        let mut active = stopped(10);
+        active.active = true;
+        assert_eq!(
+            response_since(Some(active), Some(active)),
+            MicResponse::Observed
+        );
+        assert_eq!(response_since(None, Some(active)), MicResponse::Observed);
+    }
+
+    #[test]
+    fn new_completed_recording_is_a_response() {
+        assert_eq!(
+            response_since(Some(stopped(10)), Some(stopped(20))),
+            MicResponse::Observed
+        );
+    }
+
+    #[test]
+    fn unchanged_inactive_recording_allows_recovery() {
+        assert_eq!(
+            response_since(Some(stopped(10)), Some(stopped(10))),
+            MicResponse::NotObserved
+        );
+    }
+
+    #[test]
+    fn missing_or_regressed_observations_do_not_authorize_recovery() {
+        assert_eq!(response_since(None, None), MicResponse::Unknown);
+        assert_eq!(
+            response_since(Some(stopped(10)), None),
+            MicResponse::Unknown
+        );
+        assert_eq!(
+            response_since(None, Some(stopped(10))),
+            MicResponse::Unknown
+        );
+        assert_eq!(
+            response_since(Some(stopped(20)), Some(stopped(10))),
+            MicResponse::Unknown
+        );
+    }
 }


### PR DESCRIPTION
## 修复的问题

1. **v0.2.3 启动卡死**：恢复已保存的遥控器时，BLE 清理会请求音频中断。`AudioMessage::Interrupt` 新增日志在同一条 `format!` 表达式中两次获取同一个不可重入 Mutex，导致音频线程死锁，首次 UI 状态读取也随之阻塞。改为一次取出字段、释放锁后再记录日志。
2. **RC003 长按语音反复中断、恢复**：WeType 检测只读取首条 ConsentStore 历史记录。受影响主机存在七个版本的记录，首条属于旧版本，检测器因此误判当前录音未响应并触发输入法切换、快捷键释放及重注入。现在汇总所有匹配记录，识别正在录音的状态，在注入前获取基线，并在观测不可用时跳过恢复。延迟后的重试再次核对麦克风和会话状态；过期重试不再丢失当前按住的快捷键记录。

保持原有 700 ms 检测窗口、重试间隔、按键注入间隔及 ATVV 续期间隔。改动集中在三个 Windows 平台模块及对应回归测试、Bug 记录。

## 验证

- Windows 音频工作线程回归：原实现两秒超时，修复后连续两次中断及退出通过。
- `pnpm test`：52 项通过；`pnpm build` 通过。
- `cargo test --workspace --release --locked -- --test-threads=4` 通过，Windows 平台部分 83 项通过。需要额外外部条件的测试保持显式 ignored。
- `cargo fmt --all -- --check`、`git diff --check` 通过。
- 单独运行只读 ConsentStore 测试通过，实际识别七条 WeType 记录。
- Windows x64 发布版构建通过。受影响主机上，音频中断完成耗时 0 ms，首次前端 IPC 完成，窗口正常响应并完成 RC003 ATVV 握手。
- RC003 + WeType 2.1.3.18 + VB-CABLE 实测：用户确认持续说话不中断、松手才结束。两次日志中的长按约 13 秒，均在 attempt 0 检测到录音，MIC_EXTEND 正常、快捷键释放和音频排空成功；后一次在闲置近四分钟后开始。

验证边界：历史 v0.2.2 故障会话日志不可用，原始中断现象来自用户反馈；本次 RC001 真机、完整安装器升级矩阵仍待验证。未上传语音、转写正文、设备身份或个人路径。

上游仓库关闭了 Issues，因此两个问题的复现与修复说明集中记录在本 PR 和 `Bugs/2026-09-09-*.md` 中。
