### PR TITLE
release: bump version to 0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3103,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "sayall-core"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -3112,7 +3112,7 @@ dependencies = [
 
 [[package]]
 name = "sayall-windows"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "futures",
  "sayall-core",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "sayall-windows-app"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "quick-xml",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 license = "GPL-3.0-only"
 repository = "https://github.com/GetSayAll/remote-mic-app-windows"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sayall-windows",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.15.0",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "无线麦 SayAll",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "identifier": "app.getsayall.remote-mic.windows",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary
- bump workspace, frontend, lockfile, and Tauri package versions to 0.2.4
- publish the startup-deadlock fix from PR #48 as a new immutable patch version

## Verification
- scripts/ci-preflight.ps1 -Full (7/7 passed)
- release startup regression with persisted audio endpoint (passed on PR #48)
- RC001 and RC003 hardware verification: deferred
- Authenticode: not configured; preview release must disclose this boundary