### PR TITLE
release: bump version to 0.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3103,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "sayall-core"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -3112,7 +3112,7 @@ dependencies = [
 
 [[package]]
 name = "sayall-windows"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "futures",
  "sayall-core",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "sayall-windows-app"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "quick-xml",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "GPL-3.0-only"
 repository = "https://github.com/GetSayAll/remote-mic-app-windows"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sayall-windows",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.15.0",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "无线麦 SayAll",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "identifier": "app.getsayall.remote-mic.windows",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## 内容

- 将 workspace、前端和 Tauri 应用版本统一升级为 0.2.5
- 发布内容包含 PR #51：按键映射显式保存、导入和导出

## 本地验证

- scripts/ci-preflight.ps1：前端、Rust 工作区、Tauri host 均通过
- 隔离目录 release runtime-simulation 构建：passed
- 本地 NSIS 测试包构建：passed
- 已安装 0.2.4 -> 0.2.5 /S /UPDATE：passed
- settings.json 与 button-mappings.json 升级前后哈希一致
- RC001 / RC003 真机：deferred