### PR TITLE
fix: avoid false WeType recovery from stale ConsentStore history

### DIFF
--- a/Bugs/2026-09-09-wetype-history-false-recovery.md
+++ b/Bugs/2026-09-09-wetype-history-false-recovery.md
@@ -1,0 +1,14 @@
+# WeType history can interrupt a continuously held voice key
+
+- Discovered: 2026-09-09.
+- Status: fixed in source; RC003 and WeType end-to-end acceptance pending.
+- Scope: Windows v0.2.2 and v0.2.3, RC003 with WeType.
+- Symptom: dictation starts, stops after roughly one second, then restarts and stops repeatedly while the remote voice key remains held.
+- Trigger: multiple historical WeType executable entries in Windows microphone ConsentStore.
+- Expected: one chord DOWN/UP pair for one physical voice hold, without restarting an already active recording.
+- Evidence: the affected host has seven WeType history entries. The original enumeration returns the first, version 2.1.0.36 last used in July; the running version is 2.1.3.18 and the seventh entry updates in September. The original 700 ms detector reads the old entry, invokes TSF profile cycling, and schedules release/repress after 2, 3, and 5 seconds. Historical v0.2.2 session logs were unavailable, so the exact prior on-screen sequence remains user-reported.
+- Cause: first-match registry enumeration is not current-version selection. The detector also captured its baseline after injection and treated an unavailable observation as failure. A queued stale retry removed held_hotkey before checking its session epoch.
+- Fix: aggregate all matching entries, recognize active microphone use via LastUsedTimeStop, capture the baseline before injection, and suppress recovery for unknown observations. Recheck after the recovery delay and before releasing a chord. Validate session identity before consuming the held chord, preserving cleanup ownership if release fails.
+- Timing: existing 700 ms checks, retry delays, chord spacing, and ATVV extension intervals are unchanged.
+- Validation: five regression cases cover version history/order, an already active baseline, newly completed recording, genuinely unchanged inactive history, and unavailable/regressed observations. A separate ignored Windows test reads only aggregate observation availability and counts.
+- Privacy: registry reads use the public Windows microphone access history. No WeType private configuration is read or written; diagnostics contain no paths, raw timestamps, voice data, or input text.

--- a/Bugs/2026-09-09-wetype-history-false-recovery.md
+++ b/Bugs/2026-09-09-wetype-history-false-recovery.md
@@ -1,7 +1,7 @@
 # WeType history can interrupt a continuously held voice key
 
 - Discovered: 2026-09-09.
-- Status: fixed in source; RC003 and WeType end-to-end acceptance pending.
+- Status: fixed; RC003 and WeType continuous-hold acceptance passed on the affected Windows host.
 - Scope: Windows v0.2.2 and v0.2.3, RC003 with WeType.
 - Symptom: dictation starts, stops after roughly one second, then restarts and stops repeatedly while the remote voice key remains held.
 - Trigger: multiple historical WeType executable entries in Windows microphone ConsentStore.
@@ -11,4 +11,5 @@
 - Fix: aggregate all matching entries, recognize active microphone use via LastUsedTimeStop, capture the baseline before injection, and suppress recovery for unknown observations. Recheck after the recovery delay and before releasing a chord. Validate session identity before consuming the held chord, preserving cleanup ownership if release fails.
 - Timing: existing 700 ms checks, retry delays, chord spacing, and ATVV extension intervals are unchanged.
 - Validation: five regression cases cover version history/order, an already active baseline, newly completed recording, genuinely unchanged inactive history, and unavailable/regressed observations. A separate ignored Windows test reads only aggregate observation availability and counts.
+- Hardware acceptance: the user confirmed uninterrupted dictation ending only on physical release. Two captured holds lasted about 13 seconds each, with WeType response detected on attempt 0, periodic MIC_EXTEND commands, and one successful chord release followed by successful audio drain. The later hold started after almost four minutes idle. RC001 hardware and installer upgrade acceptance remain deferred for this patch.
 - Privacy: registry reads use the public Windows microphone access history. No WeType private configuration is read or written; diagnostics contain no paths, raw timestamps, voice data, or input text.

--- a/crates/sayall-windows/src/ble.rs
+++ b/crates/sayall-windows/src/ble.rs
@@ -1,3 +1,4 @@
+use crate::wetype_revive::{response_since, wetype_mic_observation, MicObservation, MicResponse};
 use crate::{
     audio::AudioRuntime, power::PowerNotifications, reconnect::ReconnectBackoff,
     remote_model_from_model_number, remote_model_from_name, send_input::KeyChord,
@@ -178,6 +179,7 @@ pub(crate) enum WorkerMessage {
     RetryVoiceChord {
         attempt: u32,
         epoch: u64,
+        baseline: Option<MicObservation>,
     },
     Control {
         connection_generation: u64,
@@ -526,40 +528,59 @@ fn worker_loop(
                     // 撞上配置切换重绑窗口的自伤风险，已移除）。
                 }
             }
-            WorkerMessage::RetryVoiceChord { attempt, epoch } => {
+            WorkerMessage::RetryVoiceChord {
+                attempt,
+                epoch,
+                baseline,
+            } => {
                 // 微信输入法热键休眠的自动重试（同一次按住内完成）：
                 // 释放旧和弦边沿 → 重注入。在工作线程内串行执行，与
                 // StreamStopped/中止路径无竞态；仅在会话仍在流式且纪元
                 // 未变（未被新会话替换）时执行。
+                // Validate before taking ownership: a stale retry must never
+                // discard the chord needed to release the current session.
+                if pipeline.state() != VoiceSessionState::Streaming
+                    || voice_session_epoch.load(Ordering::SeqCst) != epoch
+                {
+                    gatt_note(format!("chord_retry skipped reason=stale epoch={epoch}"));
+                    continue;
+                }
+                let retry_baseline = wetype_mic_observation();
+                if response_since(baseline, retry_baseline) != MicResponse::NotObserved {
+                    gatt_note(format!(
+                        "chord_retry skipped reason=mic_active_or_unknown epoch={epoch}"
+                    ));
+                    continue;
+                }
                 let chord_configured = lock(&voice_hold_hotkey).clone();
-                let old_held = held_hotkey.take();
-                if let (Some(chord), Some(old)) = (chord_configured, old_held) {
-                    if pipeline.state() == VoiceSessionState::Streaming
-                        && voice_session_epoch.load(Ordering::SeqCst) == epoch
-                    {
-                        let _ = send_input.release(&old);
-                        match send_input.press(&chord) {
-                            Ok(_) => {
-                                gatt_note(format!(
-                                    "chord_retry result=ok attempt={attempt} epoch={epoch}"
-                                ));
-                                held_hotkey = Some(chord);
-                                spawn_wetype_check(
-                                    &state,
-                                    sender.clone(),
-                                    attempt,
-                                    epoch,
-                                    &voice_session_epoch,
-                                );
-                            }
-                            Err(_) => {
-                                gatt_note(format!(
+                if let (Some(chord), Some(old)) = (chord_configured, held_hotkey.as_ref()) {
+                    if send_input.release(old).is_err() {
+                        gatt_note(format!(
+                            "chord_retry result=err reason=release_failed epoch={epoch}"
+                        ));
+                        continue;
+                    }
+                    held_hotkey = None;
+                    match send_input.press(&chord) {
+                        Ok(_) => {
+                            gatt_note(format!(
+                                "chord_retry result=ok attempt={attempt} epoch={epoch}"
+                            ));
+                            held_hotkey = Some(chord);
+                            spawn_wetype_check(
+                                &state,
+                                sender.clone(),
+                                attempt,
+                                epoch,
+                                &voice_session_epoch,
+                                retry_baseline,
+                            );
+                        }
+                        Err(_) => {
+                            gatt_note(format!(
                                     "chord_retry result=err attempt={attempt} epoch={epoch} error_domain=send_input error_code=retry_failed reason=injection_failed retryable=true"
                                 ));
-                            }
                         }
-                    } else {
-                        gatt_note(format!("chord_retry skipped reason=stale epoch={epoch}"));
                     }
                 } else {
                     gatt_note("chord_retry skipped reason=no_chord".to_owned());
@@ -1025,6 +1046,7 @@ fn handle_control(
             // 按住说话快捷键（参考 ZSTDJan/Voice_VibeCoding）：先注入快捷键
             // DOWN，再开始音频会话；注入失败直接中止本次会话并统一释放。
             if let Some(chord) = lock(voice_hold_hotkey).clone() {
+                let mic_baseline = wetype_mic_observation();
                 // 会话级激活微信输入法：其语音热键只在自身为当前会话活动
                 // 输入法时生效（2026-09-05 持锁实验，evidence/p）；激活后零
                 // 延迟注入 3/3 触发，不增加按键延迟。失败仅记录提示，按原
@@ -1058,7 +1080,14 @@ fn handle_control(
                 // WeType 热键休眠检测与自动恢复（见 spawn_wetype_check）。
                 // 纪元在 StreamStarted 顶部已递增并捕获（见上），连同引用
                 // 传入，防旧阶梯跨会话误伤新会话的和弦。
-                spawn_wetype_check(state, sender.clone(), 0, epoch, voice_session_epoch);
+                spawn_wetype_check(
+                    state,
+                    sender.clone(),
+                    0,
+                    epoch,
+                    voice_session_epoch,
+                    mic_baseline,
+                );
             } else {
                 // 功能点日志：会话开始但未配置按住说话快捷键（无注入环节）。
                 gatt_note(format!(
@@ -1701,12 +1730,13 @@ fn spawn_wetype_check(
     attempt: u32,
     epoch: u64,
     epoch_ref: &Arc<AtomicU64>,
+    baseline: Option<MicObservation>,
 ) {
     let state = Arc::clone(state);
     let epoch_ref = Arc::clone(epoch_ref);
-    let baseline = crate::wetype_revive::wetype_mic_start();
     gatt_note(format!(
-        "wetype_check armed attempt={attempt} epoch={epoch} baseline={baseline:?}"
+        "wetype_check armed attempt={attempt} epoch={epoch} baseline_available={}",
+        baseline.is_some()
     ));
     std::thread::Builder::new()
         .name("sayall-wetype-check".to_owned())
@@ -1729,17 +1759,20 @@ fn spawn_wetype_check(
                 });
                 return;
             }
-            let now = crate::wetype_revive::wetype_mic_start();
-            let reacted = match (baseline, now) {
-                (Some(base), Some(current)) => current > base,
-                (None, Some(_)) => true,
-                _ => false,
-            };
-            if reacted {
-                gatt_note(format!(
-                    "wetype_check reacted=true attempt={attempt} epoch={epoch}"
-                ));
-                return;
+            match response_since(baseline, wetype_mic_observation()) {
+                MicResponse::Observed => {
+                    gatt_note(format!(
+                        "wetype_check reacted=true attempt={attempt} epoch={epoch}"
+                    ));
+                    return;
+                }
+                MicResponse::Unknown => {
+                    gatt_note(format!(
+                        "wetype_check skipped reason=observation_unavailable attempt={attempt} epoch={epoch}"
+                    ));
+                    return;
+                }
+                MicResponse::NotObserved => {}
             }
             if attempt >= WETYPE_RETRY_MAX_ATTEMPT {
                 // 最后一轮仍未响应：放弃自动恢复，提示人工（唯一兜底）。
@@ -1757,7 +1790,8 @@ fn spawn_wetype_check(
             ));
             let revive = crate::ime::cycle_wetype_profile();
             gatt_note(format!(
-                "wetype_revive result={revive:?} attempt={attempt} epoch={epoch}"
+                "wetype_revive result={} attempt={attempt} epoch={epoch}",
+                if revive.is_ok() { "ok" } else { "err" }
             ));
             std::thread::sleep(std::time::Duration::from_millis(
                 WETYPE_RETRY_SETTLE_MS[attempt as usize],
@@ -1779,10 +1813,17 @@ fn spawn_wetype_check(
                 });
                 return;
             }
+            if response_since(baseline, wetype_mic_observation()) != MicResponse::NotObserved {
+                gatt_note(format!(
+                    "wetype_check skipped_retry reason=mic_active_or_unknown attempt={attempt} epoch={epoch}"
+                ));
+                return;
+            }
             let next_attempt = attempt + 1;
             let _ = sender.send(WorkerMessage::RetryVoiceChord {
                 attempt: next_attempt,
                 epoch,
+                baseline,
             });
         })
         .ok();

--- a/crates/sayall-windows/src/wetype_revive.rs
+++ b/crates/sayall-windows/src/wetype_revive.rs
@@ -1,30 +1,80 @@
-//! ConsentStore 微信输入法（WeType）开麦判据读取。
-//!
-//! 用途（2026-09-05 WeType 热键休眠调查）：WeType 内部状态不可观测，
-//! ConsentStore 的 LastUsedTimeStart 时间戳是"微信输入法真的响应并打开了
-//! 麦克风"的唯一公开判据——与整晚持锁实验的 ground truth 相同。
-//! 供 ble.rs 的 wetype_check（热键休眠检测与自动恢复）使用。
-//!
-//! 历史注记：曾实现"对 WeType 进程解除后台节流"作为唤醒手段，真机实证
-//! 跨进程 SetProcessInformation(ProcessPowerThrottling) 返回 E_INVALIDARG
-//! （不支持作用于其他进程），方案已由 ime.rs 的 TSF 配置切换唤醒取代。
+//! Observe WeType microphone use through the public Windows ConsentStore.
+//! Updates leave historical executable entries behind; enumeration order is
+//! unrelated to the version that is currently recording.
 
+use windows::Win32::Foundation::ERROR_NO_MORE_ITEMS;
 use windows::Win32::System::Registry::{
     RegCloseKey, RegEnumKeyExW, RegOpenKeyExW, RegQueryValueExW, HKEY, HKEY_CURRENT_USER, KEY_READ,
-    REG_VALUE_TYPE,
+    REG_QWORD, REG_VALUE_TYPE,
 };
 
-/// ConsentStore microphone\NonPackaged 根键。
 const CONSENT_NONPACKAGED: &str =
     "Software\\Microsoft\\Windows\\CurrentVersion\\CapabilityAccessManager\\ConsentStore\\microphone\\NonPackaged";
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct MicObservation {
+    latest_start: u64,
+    active: bool,
+    entries: usize,
+}
+
+impl MicObservation {
+    fn record(&mut self, start: u64, stop: u64) {
+        self.latest_start = self.latest_start.max(start);
+        self.active |= start > 0 && stop == 0;
+        self.entries += 1;
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MicResponse {
+    Observed,
+    NotObserved,
+    Unknown,
+}
+
+pub(crate) fn response_since(
+    baseline: Option<MicObservation>,
+    current: Option<MicObservation>,
+) -> MicResponse {
+    match (baseline, current) {
+        (_, Some(current)) if current.active => MicResponse::Observed,
+        (Some(base), Some(current)) if current.latest_start > base.latest_start => {
+            MicResponse::Observed
+        }
+        (Some(base), Some(current))
+            if current.entries >= base.entries && current.latest_start == base.latest_start =>
+        {
+            MicResponse::NotObserved
+        }
+        _ => MicResponse::Unknown,
+    }
+}
 
 fn wide(text: &str) -> Vec<u16> {
     text.encode_utf16().chain([0]).collect()
 }
 
-/// 读取 WeType 的最近开麦时间戳（原始 FILETIME，100ns 单位）。
-/// 未找到 WeType 条目或读取失败返回 None（调用方按"无法判定"处理）。
-pub fn wetype_mic_start() -> Option<u64> {
+fn read_qword(key: HKEY, name: &str) -> Option<u64> {
+    let value = wide(name);
+    let mut data = 0_u64;
+    let mut size = std::mem::size_of::<u64>() as u32;
+    let mut kind = REG_VALUE_TYPE::default();
+    let result = unsafe {
+        RegQueryValueExW(
+            key,
+            windows::core::PCWSTR(value.as_ptr()),
+            None,
+            Some(&mut kind),
+            Some((&mut data as *mut u64).cast()),
+            Some(&mut size),
+        )
+    };
+    (result.0 == 0 && kind == REG_QWORD && size == 8).then_some(data)
+}
+
+/// Missing or partially unreadable observations must not trigger recovery.
+pub(crate) fn wetype_mic_observation() -> Option<MicObservation> {
     let subkey = wide(CONSENT_NONPACKAGED);
     let mut root = HKEY::default();
     if unsafe {
@@ -40,11 +90,13 @@ pub fn wetype_mic_start() -> Option<u64> {
     {
         return None;
     }
-    let mut index: u32 = 0;
+    let mut index = 0;
+    let mut observation = MicObservation::default();
+    let mut complete = true;
     loop {
         let mut name = [0u16; 260];
         let mut len = name.len() as u32;
-        if unsafe {
+        let result = unsafe {
             RegEnumKeyExW(
                 root,
                 index,
@@ -55,14 +107,17 @@ pub fn wetype_mic_start() -> Option<u64> {
                 None,
                 None,
             )
+        };
+        if result == ERROR_NO_MORE_ITEMS {
+            break;
         }
-        .0 != 0
-        {
+        if result.0 != 0 {
+            complete = false;
             break;
         }
         index += 1;
-        let entry = String::from_utf16_lossy(&name[..len as usize]).to_lowercase();
-        if !entry.contains("wetype") {
+        let entry = String::from_utf16_lossy(&name[..len as usize]);
+        if !entry.to_ascii_lowercase().contains("wetype") {
             continue;
         }
         let mut key = HKEY::default();
@@ -78,34 +133,110 @@ pub fn wetype_mic_start() -> Option<u64> {
         }
         .0 != 0
         {
+            complete = false;
             continue;
         }
-        let value = wide("LastUsedTimeStart");
-        let mut data: u64 = 0;
-        let mut size = std::mem::size_of::<u64>() as u32;
-        let mut kind = REG_VALUE_TYPE::default();
-        let queried = unsafe {
-            RegQueryValueExW(
-                key,
-                windows::core::PCWSTR(value.as_ptr()),
-                None,
-                Some(&mut kind),
-                Some((&mut data as *mut u64).cast()),
-                Some(&mut size),
-            )
-        };
+        let start = read_qword(key, "LastUsedTimeStart");
+        let stop = read_qword(key, "LastUsedTimeStop");
         unsafe {
             let _ = RegCloseKey(key);
         }
-        if queried.0 == 0 {
-            unsafe {
-                let _ = RegCloseKey(root);
-            }
-            return Some(data);
+        match (start, stop) {
+            (Some(start), Some(stop)) => observation.record(start, stop),
+            _ => complete = false,
         }
     }
     unsafe {
         let _ = RegCloseKey(root);
     }
-    None
+    (complete && observation.entries > 0).then_some(observation)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[ignore = "requires installed WeType microphone history; read-only"]
+    fn live_consentstore_observation_is_readable() {
+        let observation = wetype_mic_observation().expect("WeType observation unavailable");
+        assert!(observation.entries > 0);
+        println!(
+            "wetype_observation entries={} active={}",
+            observation.entries, observation.active
+        );
+    }
+
+    fn stopped(start: u64) -> MicObservation {
+        let mut result = MicObservation::default();
+        result.record(start, start + 1);
+        result
+    }
+
+    #[test]
+    fn historical_versions_do_not_hide_current_recording() {
+        let mut baseline = MicObservation::default();
+        for start in [10, 20, 30, 40, 50, 60, 70] {
+            baseline.record(start, start + 1);
+        }
+        let mut current = MicObservation::default();
+        for start in [10, 20, 30, 40, 50, 60] {
+            current.record(start, start + 1);
+        }
+        current.record(80, 0);
+        assert_eq!(
+            response_since(Some(baseline), Some(current)),
+            MicResponse::Observed
+        );
+        let mut reversed = MicObservation::default();
+        reversed.record(80, 0);
+        for start in [60, 50, 40, 30, 20, 10] {
+            reversed.record(start, start + 1);
+        }
+        assert_eq!(current, reversed);
+    }
+
+    #[test]
+    fn active_recording_is_not_retried_even_if_baseline_already_contains_start() {
+        let mut active = stopped(10);
+        active.active = true;
+        assert_eq!(
+            response_since(Some(active), Some(active)),
+            MicResponse::Observed
+        );
+        assert_eq!(response_since(None, Some(active)), MicResponse::Observed);
+    }
+
+    #[test]
+    fn new_completed_recording_is_a_response() {
+        assert_eq!(
+            response_since(Some(stopped(10)), Some(stopped(20))),
+            MicResponse::Observed
+        );
+    }
+
+    #[test]
+    fn unchanged_inactive_recording_allows_recovery() {
+        assert_eq!(
+            response_since(Some(stopped(10)), Some(stopped(10))),
+            MicResponse::NotObserved
+        );
+    }
+
+    #[test]
+    fn missing_or_regressed_observations_do_not_authorize_recovery() {
+        assert_eq!(response_since(None, None), MicResponse::Unknown);
+        assert_eq!(
+            response_since(Some(stopped(10)), None),
+            MicResponse::Unknown
+        );
+        assert_eq!(
+            response_since(None, Some(stopped(10))),
+            MicResponse::Unknown
+        );
+        assert_eq!(
+            response_since(Some(stopped(20)), Some(stopped(10))),
+            MicResponse::Unknown
+        );
+    }
 }


### PR DESCRIPTION
## 来源与归属

本 PR 从 @Peytonlukm 的 #47 提取仍未合入 main 的 WeType 修复。两个提交均保留原始作者，commit Author 已使用其 GitHub noreply 地址；提交正文保留原 commit SHA。启动音频日志死锁已由 #48 合入，因此未重复移植。

Closes the remaining WeType portion of #47.

## 修复

- 汇总全部 WeType ConsentStore 历史条目，不再依赖枚举顺序
- 同时观察 LastUsedTimeStart / LastUsedTimeStop，识别当前正在录音的条目
- 在快捷键注入前捕获基线，避免在 700 ms 检查窗内启动的录音被误判
- 观测缺失或回退时 fail-safe，避免自动恢复误伤当前会话
- 重试前再次检查会话 epoch 和麦克风状态；只有成功释放旧和弦后才转移 held chord 所有权

## 验证

- WeType 判定回归：5 passed，1 ignored
- 本机 ConsentStore 只读探针：passed；当前主机读取 1 条记录
- `scripts/ci-preflight.ps1`：6/6 passed
- 原作者 RC003 + WeType 持续按住验收：两次约 13 秒，后一次空闲近 4 分钟后启动；详见 Bug 记录
- 当前主机的多历史版本场景及 RC001/RC003 本轮真机复测：deferred
