### PR TITLE
ci: skip community image-only changes

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -8,6 +8,7 @@ on:
       - 'docs/**'
       - 'Testing/**'
       - 'artifacts/**'
+      - 'Screenshots/**'
       - '.gitignore'
       - 'LICENSE'
   pull_request:
@@ -16,6 +17,7 @@ on:
       - 'docs/**'
       - 'Testing/**'
       - 'artifacts/**'
+      - 'Screenshots/**'
       - '.gitignore'
       - 'LICENSE'
 


### PR DESCRIPTION
## Summary
- ignore `Screenshots/**` for push and pull-request CI triggers
- keep README/community image-only synchronization fast and free of the full Windows build

## Validation
- cargo fmt --all -- --check
- git diff --check