### PR TITLE
发布 v0.2.6 预览版

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3103,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "sayall-core"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -3112,7 +3112,7 @@ dependencies = [
 
 [[package]]
 name = "sayall-windows"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "futures",
  "sayall-core",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "sayall-windows-app"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "quick-xml",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 license = "GPL-3.0-only"
 repository = "https://github.com/GetSayAll/remote-mic-app-windows"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sayall-windows",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.15.0",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "无线麦 SayAll",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "identifier": "app.getsayall.remote-mic.windows",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## 发布内容

- 修复按键映射中的 Win+L 锁屏动作，成功后清理延迟释放状态
- 默认保留直接快捷键录入，增加可选“安全录入模式”，避免系统快捷键在录入时执行
- 调整安全录入开关、提示词与连接/语音状态圆点的界面对齐
- 版本由 0.2.5 升至 0.2.6

## 验证

- `scripts/ci-preflight.ps1`: passed（6/6）
- 前端：58 passed
- Rust workspace：87 passed，2 ignored（硬件/环境依赖）
- Tauri：16 passed，1 ignored（在线预览通道检查）
- 本地 0.2.5 安装、升级、启动：passed
- RC003 电源单击映射 Win+L 锁屏：passed（用户现场确认）
- RC001 对本改动的真机回归：deferred
- 安全录入模式安装现场复验：deferred

## 发布边界

本 PR 只更新版本元数据。合入后从精确 `main` SHA 打 `v0.2.6` 标签，触发签名发布流水线并创建 Draft Release；核对资产后发布为 prerelease。